### PR TITLE
feat: replace HN with wikipedia

### DIFF
--- a/script.py
+++ b/script.py
@@ -5,14 +5,14 @@ from time import sleep, time
 from scrapers.scraper import connect_to_base, get_driver, parse_html, write_to_file
 
 
-def run_process(page_number, filename, browser):
-    if connect_to_base(browser, page_number):
+def run_process(filename, browser):
+    if connect_to_base(browser):
         sleep(2)
         html = browser.page_source
         output_list = parse_html(html)
         write_to_file(output_list, filename)
     else:
-        print("Error connecting to hacker news")
+        print("Error connecting to Wikipedia")
 
 
 if __name__ == "__main__":
@@ -26,7 +26,7 @@ if __name__ == "__main__":
 
     # set variables
     start_time = time()
-    current_page = 1
+    current_attempt = 1
     output_timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
     output_filename = f"output_{output_timestamp}.csv"
 
@@ -34,10 +34,10 @@ if __name__ == "__main__":
     browser = get_driver(headless=headless)
 
     # scrape and crawl
-    while current_page <= 20:
-        print(f"Scraping page #{current_page}...")
-        run_process(current_page, output_filename, browser)
-        current_page = current_page + 1
+    while current_attempt <= 20:
+        print(f"Scraping Wikipedia #{current_attempt} time(s)...")
+        run_process(output_filename, browser)
+        current_attempt = current_attempt + 1
 
     # exit
     browser.quit()

--- a/script_asyncio.py
+++ b/script_asyncio.py
@@ -7,12 +7,12 @@ from time import sleep, time
 from scrapers.scraper import connect_to_base, get_driver, parse_html, write_to_file
 
 
-def run_process(page_number, filename, headless):
+def run_process(filename, headless):
 
     # init browser
     browser = get_driver(headless)
 
-    if connect_to_base(browser, page_number):
+    if connect_to_base(browser):
         sleep(2)
         html = browser.page_source
         output_list = parse_html(html)
@@ -21,7 +21,7 @@ def run_process(page_number, filename, headless):
         # exit
         browser.quit()
     else:
-        print("Error connecting to hackernews")
+        print("Error connecting to Wikipedia")
         browser.quit()
 
 
@@ -41,7 +41,7 @@ async def run_blocking_tasks(executor):
 
     # scrape and crawl
     blocking_tasks = [
-        loop.run_in_executor(executor, run_process, i, output_filename, headless)
+        loop.run_in_executor(executor, run_process, output_filename, headless)
         for i in range(1, 21)
     ]
     completed, pending = await asyncio.wait(blocking_tasks)

--- a/script_concurrent.py
+++ b/script_concurrent.py
@@ -6,12 +6,12 @@ from time import sleep, time
 from scrapers.scraper import connect_to_base, get_driver, parse_html, write_to_file
 
 
-def run_process(page_number, filename, headless):
+def run_process(filename, headless):
 
     # init browser
     browser = get_driver(headless)
 
-    if connect_to_base(browser, page_number):
+    if connect_to_base(browser):
         sleep(2)
         html = browser.page_source
         output_list = parse_html(html)
@@ -20,7 +20,7 @@ def run_process(page_number, filename, headless):
         # exit
         browser.quit()
     else:
-        print("Error connecting to hackernews")
+        print("Error connecting to Wikipedia")
         browser.quit()
 
 
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     with ThreadPoolExecutor() as executor:
         for number in range(1, 21):
             futures.append(
-                executor.submit(run_process, number, output_filename, headless)
+                executor.submit(run_process, output_filename, headless)
             )
 
     wait(futures)

--- a/script_parallel_1.py
+++ b/script_parallel_1.py
@@ -7,12 +7,12 @@ from time import sleep, time
 from scrapers.scraper import connect_to_base, get_driver, parse_html, write_to_file
 
 
-def run_process(page_number, filename, headless):
+def run_process(filename, headless):
 
     # init browser
     browser = get_driver(headless)
 
-    if connect_to_base(browser, page_number):
+    if connect_to_base(browser):
         sleep(2)
         html = browser.page_source
         output_list = parse_html(html)
@@ -21,7 +21,7 @@ def run_process(page_number, filename, headless):
         # exit
         browser.quit()
     else:
-        print("Error connecting to hackernews")
+        print("Error connecting to Wikipedia")
         browser.quit()
 
 
@@ -41,7 +41,7 @@ if __name__ == "__main__":
 
     # scrape and craw
     with Pool(cpu_count() - 1) as p:
-        p.starmap(run_process, zip(range(1, 21), repeat(output_filename), repeat(headless)))
+        p.starmap(run_process, repeat(output_filename), repeat(headless)))
     p.close()
     p.join()
 

--- a/script_parallel_2.py
+++ b/script_parallel_2.py
@@ -6,12 +6,12 @@ from time import sleep, time
 from scrapers.scraper import connect_to_base, get_driver, parse_html, write_to_file
 
 
-def run_process(page_number, filename, headless):
+def run_process(filename, headless):
 
     # init browser
     browser = get_driver(headless)
 
-    if connect_to_base(browser, page_number):
+    if connect_to_base(browser):
         sleep(2)
         html = browser.page_source
         output_list = parse_html(html)
@@ -20,7 +20,7 @@ def run_process(page_number, filename, headless):
         # exit
         browser.quit()
     else:
-        print("Error connecting to hackernews")
+        print("Error connecting to Wikipedia")
         browser.quit()
 
 
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     with ProcessPoolExecutor() as executor:
         for number in range(1, 21):
             futures.append(
-                executor.submit(run_process, number, output_filename, headless)
+                executor.submit(run_process, output_filename, headless)
             )
 
     wait(futures)

--- a/test/test.html
+++ b/test/test.html
@@ -1,152 +1,1177 @@
+<!DOCTYPE html><html class="client-nojs" lang="en" dir="ltr">
 
-<!-- saved from url=(0037)https://news.ycombinator.com/news?p=1 -->
-<html op="news"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta name="referrer" content="origin"><meta name="viewport" content="width=device-width, initial-scale=1.0"><link rel="stylesheet" type="text/css" href="./test_files/news.css">
-        <link rel="shortcut icon" href="https://news.ycombinator.com/favicon.ico">
-          <link rel="alternate" type="application/rss+xml" title="RSS" href="https://news.ycombinator.com/rss">
-        <title>Hacker News</title></head><body><center><table id="hnmain" border="0" cellpadding="0" cellspacing="0" width="85%" bgcolor="#f6f6ef">
-        <tbody><tr><td bgcolor="#ff6600"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="padding:2px"><tbody><tr><td style="width:18px;padding-right:4px"><a href="https://news.ycombinator.com/"><img src="./test_files/y18.gif" width="18" height="18" style="border:1px white solid;"></a></td>
-                  <td style="line-height:12pt; height:10px;"><span class="pagetop"><b class="hnname"><a href="https://news.ycombinator.com/news">Hacker News</a></b>
-              <a href="https://news.ycombinator.com/newest">new</a> | <a href="https://news.ycombinator.com/newcomments">comments</a> | <a href="https://news.ycombinator.com/show">show</a> | <a href="https://news.ycombinator.com/ask">ask</a> | <a href="https://news.ycombinator.com/jobs">jobs</a> | <a href="https://news.ycombinator.com/submit">submit</a>            </span></td><td style="text-align:right;padding-right:4px;"><span class="pagetop">
-                              <a href="https://news.ycombinator.com/login?goto=news%3Fp%3D1">login</a>
-                          </span></td>
-              </tr></tbody></table></td></tr>
-<tr style="height:10px"></tr><tr><td><table border="0" cellpadding="0" cellspacing="0" class="itemlist">
-              <tbody><tr class="athing" id="16308961">
-      <td align="right" valign="top" class="title"><span class="rank">1.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16308961" href="https://news.ycombinator.com/vote?id=16308961&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://www.reuters.com/article/us-usa-equifax-cfpb/exclusive-u-s-consumer-protection-official-puts-equifax-probe-on-ice-sources-idUSKBN1FP0IZ#ref" class="storylink">U.S. consumer protection official puts Equifax probe on ice</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=reuters.com"><span class="sitestr">reuters.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16308961">502 points</span> by <a href="https://news.ycombinator.com/user?id=chatmasta" class="hnuser">chatmasta</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16308961">3 hours ago</a></span> <span id="unv_16308961"></span> | <a href="https://news.ycombinator.com/hide?id=16308961&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16308961">210&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16309622">
-      <td align="right" valign="top" class="title"><span class="rank">2.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16309622" href="https://news.ycombinator.com/vote?id=16309622&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="http://www8.hp.com/us/en/printers/3d-printers/3dcolorprint.html" class="storylink">3D Color Print</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=hp.com"><span class="sitestr">hp.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16309622">100 points</span> by <a href="https://news.ycombinator.com/user?id=zwieback" class="hnuser">zwieback</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16309622">2 hours ago</a></span> <span id="unv_16309622"></span> | <a href="https://news.ycombinator.com/hide?id=16309622&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16309622">49&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16309533">
-      <td align="right" valign="top" class="title"><span class="rank">3.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16309533" href="https://news.ycombinator.com/vote?id=16309533&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://github.com/automerge/automerge" class="storylink">Automerge: JSON-like data structure for building collaborative apps</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=github.com"><span class="sitestr">github.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16309533">84 points</span> by <a href="https://news.ycombinator.com/user?id=goblin89" class="hnuser">goblin89</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16309533">2 hours ago</a></span> <span id="unv_16309533"></span> | <a href="https://news.ycombinator.com/hide?id=16309533&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16309533">38&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16303046">
-      <td align="right" valign="top" class="title"><span class="rank">4.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16303046" href="https://news.ycombinator.com/vote?id=16303046&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://www.metmuseum.org/art/metpublications/titles-with-full-text-online?searchtype=F" class="storylink">50 Years of Art Books from the Met, for Free Download</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=metmuseum.org"><span class="sitestr">metmuseum.org</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16303046">175 points</span> by <a href="https://news.ycombinator.com/user?id=brudgers" class="hnuser">brudgers</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16303046">5 hours ago</a></span> <span id="unv_16303046"></span> | <a href="https://news.ycombinator.com/hide?id=16303046&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16303046">9&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16310541">
-      <td align="right" valign="top" class="title"><span class="rank">5.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16310541" href="https://news.ycombinator.com/vote?id=16310541&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://www.economist.com/blogs/kaffeeklatsch/2018/02/28-years-two-months-and-27-days" class="storylink">The Berlin Wall has now been down longer than it was up-28 yrs, 2 months,27 days</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=economist.com"><span class="sitestr">economist.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16310541">11 points</span> by <a href="https://news.ycombinator.com/user?id=mpweiher" class="hnuser">mpweiher</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16310541">34 minutes ago</a></span> <span id="unv_16310541"></span> | <a href="https://news.ycombinator.com/hide?id=16310541&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16310541">discuss</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16310230">
-      <td align="right" valign="top" class="title"><span class="rank">6.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16310230" href="https://news.ycombinator.com/vote?id=16310230&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://torrentfreak.com/cloudflare-terminates-service-to-sci-hub-domain-names-180205/" class="storylink">Cloudflare Terminates Service to Sci-Hub Domain Names</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=torrentfreak.com"><span class="sitestr">torrentfreak.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16310230">78 points</span> by <a href="https://news.ycombinator.com/user?id=jakobdabo" class="hnuser">jakobdabo</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16310230">1 hour ago</a></span> <span id="unv_16310230"></span> | <a href="https://news.ycombinator.com/hide?id=16310230&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16310230">12&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16308626">
-      <td align="right" valign="top" class="title"><span class="rank">7.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16308626" href="https://news.ycombinator.com/vote?id=16308626&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://github.com/louisabraham/algnuth" class="storylink">Show HN: Algebraic Number Theory in Python 3</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=github.com"><span class="sitestr">github.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16308626">83 points</span> by <a href="https://news.ycombinator.com/user?id=Labo333" class="hnuser">Labo333</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16308626">4 hours ago</a></span> <span id="unv_16308626"></span> | <a href="https://news.ycombinator.com/hide?id=16308626&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16308626">18&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16310677">
-      <td align="right" valign="top" class="title"><span class="rank">8.</span></td>      <td></td><td class="title"><a href="https://jobs.lever.co/zentail/d3359e29-5201-478b-831b-d8fa03dcd27c?lever-origin=applied&amp;lever-source%5B%5D=Hacker%20News" class="storylink" rel="nofollow">Zentail (YC S12) Is Hiring a Product Developer in Columbia, MD</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=lever.co"><span class="sitestr">lever.co</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="age"><a href="https://news.ycombinator.com/item?id=16310677">16 minutes ago</a></span> | <a href="https://news.ycombinator.com/hide?id=16310677&amp;goto=news%3Fp%3D1">hide</a>      </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16308136">
-      <td align="right" valign="top" class="title"><span class="rank">9.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16308136" href="https://news.ycombinator.com/vote?id=16308136&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://crpgbook.wordpress.com/2018/02/05/update-19-crpg-book-released/" class="storylink">CRPG Book Released</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=crpgbook.wordpress.com"><span class="sitestr">crpgbook.wordpress.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16308136">199 points</span> by <a href="https://news.ycombinator.com/user?id=felipepepe" class="hnuser">felipepepe</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16308136">7 hours ago</a></span> <span id="unv_16308136"></span> | <a href="https://news.ycombinator.com/hide?id=16308136&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16308136">32&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16308667">
-      <td align="right" valign="top" class="title"><span class="rank">10.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16308667" href="https://news.ycombinator.com/vote?id=16308667&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://www.nytimes.com/2018/02/05/nyregion/cyber-crimes-unreported.html?hp" class="storylink">An ‘Iceberg’ of Unseen Crimes: Many Cyber Offenses Go Unreported</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=nytimes.com"><span class="sitestr">nytimes.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16308667">61 points</span> by <a href="https://news.ycombinator.com/user?id=ganlad" class="hnuser">ganlad</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16308667">4 hours ago</a></span> <span id="unv_16308667"></span> | <a href="https://news.ycombinator.com/hide?id=16308667&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16308667">14&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16308581">
-      <td align="right" valign="top" class="title"><span class="rank">11.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16308581" href="https://news.ycombinator.com/vote?id=16308581&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://github.com/henry-luo/mark" class="storylink">Mark – A simple and unified notation for both object and markup data</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=github.com"><span class="sitestr">github.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16308581">104 points</span> by <a href="https://news.ycombinator.com/user?id=henryluo" class="hnuser">henryluo</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16308581">5 hours ago</a></span> <span id="unv_16308581"></span> | <a href="https://news.ycombinator.com/hide?id=16308581&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16308581">119&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16292915">
-      <td align="right" valign="top" class="title"><span class="rank">12.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16292915" href="https://news.ycombinator.com/vote?id=16292915&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://medium.com/podible-engineering/pixels-are-tech-debt-ff4ff4fdeb4c" class="storylink">Pixels are Tech Debt</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=medium.com"><span class="sitestr">medium.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16292915">32 points</span> by <a href="https://news.ycombinator.com/user?id=ssalka" class="hnuser">ssalka</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16292915">2 hours ago</a></span> <span id="unv_16292915"></span> | <a href="https://news.ycombinator.com/hide?id=16292915&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16292915">27&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16308522">
-      <td align="right" valign="top" class="title"><span class="rank">13.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16308522" href="https://news.ycombinator.com/vote?id=16308522&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://www.theverge.com/2018/2/5/16966530/intel-vaunt-smart-glasses-announced-ar-video" class="storylink">Intel made smart glasses that look normal</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=theverge.com"><span class="sitestr">theverge.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16308522">225 points</span> by <a href="https://news.ycombinator.com/user?id=dphnx" class="hnuser">dphnx</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16308522">5 hours ago</a></span> <span id="unv_16308522"></span> | <a href="https://news.ycombinator.com/hide?id=16308522&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16308522">127&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16301838">
-      <td align="right" valign="top" class="title"><span class="rank">14.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16301838" href="https://news.ycombinator.com/vote?id=16301838&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://www.americanscientist.org/article/imaging-without-lenses" class="storylink">Imaging Without Lenses</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=americanscientist.org"><span class="sitestr">americanscientist.org</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16301838">115 points</span> by <a href="https://news.ycombinator.com/user?id=Gatsky" class="hnuser">Gatsky</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16301838">8 hours ago</a></span> <span id="unv_16301838"></span> | <a href="https://news.ycombinator.com/hide?id=16301838&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16301838">12&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16306744">
-      <td align="right" valign="top" class="title"><span class="rank">15.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16306744" href="https://news.ycombinator.com/vote?id=16306744&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://github.com/rage8885/OpenSC2K" class="storylink">OpenSC2K – An Open Source Remake of SimCity 2000</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=github.com"><span class="sitestr">github.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16306744">235 points</span> by <a href="https://news.ycombinator.com/user?id=LeoPanthera" class="hnuser">LeoPanthera</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16306744">13 hours ago</a></span> <span id="unv_16306744"></span> | <a href="https://news.ycombinator.com/hide?id=16306744&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16306744">108&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16308488">
-      <td align="right" valign="top" class="title"><span class="rank">16.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16308488" href="https://news.ycombinator.com/vote?id=16308488&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="http://gcaptain.com/sailors-die-sea-uscg-drone-program-remains-hard-aground/" class="storylink">Sailors Die at Sea While USCG Drone Program Remains Hard Aground</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=gcaptain.com"><span class="sitestr">gcaptain.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16308488">39 points</span> by <a href="https://news.ycombinator.com/user?id=downvote_me" class="hnuser">downvote_me</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16308488">5 hours ago</a></span> <span id="unv_16308488"></span> | <a href="https://news.ycombinator.com/hide?id=16308488&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16308488">11&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16306647">
-      <td align="right" valign="top" class="title"><span class="rank">17.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16306647" href="https://news.ycombinator.com/vote?id=16306647&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://blog.mattbierner.com/the-delimited-continuation-monad-in-javascript" class="storylink">The Delimited Continuation Monad in JavaScript (2014)</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=mattbierner.com"><span class="sitestr">mattbierner.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16306647">25 points</span> by <a href="https://news.ycombinator.com/user?id=akkartik" class="hnuser">akkartik</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16306647">4 hours ago</a></span> <span id="unv_16306647"></span> | <a href="https://news.ycombinator.com/hide?id=16306647&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16306647">5&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16309824">
-      <td align="right" valign="top" class="title"><span class="rank">18.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16309824" href="https://news.ycombinator.com/vote?id=16309824&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://blogs.msdn.microsoft.com/oldnewthing/20180205-00/?p=97965" class="storylink">// If this happens, I am going to quit and become a barista</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=microsoft.com"><span class="sitestr">microsoft.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16309824">58 points</span> by <a href="https://news.ycombinator.com/user?id=zdw" class="hnuser">zdw</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16309824">2 hours ago</a></span> <span id="unv_16309824"></span> | <a href="https://news.ycombinator.com/hide?id=16309824&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16309824">15&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16308391">
-      <td align="right" valign="top" class="title"><span class="rank">19.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16308391" href="https://news.ycombinator.com/vote?id=16308391&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://blog.hasura.io/the-ultimate-guide-to-writing-dockerfiles-for-go-web-apps-336efad7012c" class="storylink">The Ultimate Guide to Writing Dockerfiles for Go Web-Apps</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=hasura.io"><span class="sitestr">hasura.io</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16308391">53 points</span> by <a href="https://news.ycombinator.com/user?id=alberteinstein" class="hnuser">alberteinstein</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16308391">5 hours ago</a></span> <span id="unv_16308391"></span> | <a href="https://news.ycombinator.com/hide?id=16308391&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16308391">13&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16310117">
-      <td align="right" valign="top" class="title"><span class="rank">20.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16310117" href="https://news.ycombinator.com/vote?id=16310117&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="http://modern-sql.com/use-case/pivot" class="storylink" rel="nofollow">Pivot – Rows to Columns</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=modern-sql.com"><span class="sitestr">modern-sql.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16310117">5 points</span> by <a href="https://news.ycombinator.com/user?id=mooreds" class="hnuser">mooreds</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16310117">1 hour ago</a></span> <span id="unv_16310117"></span> | <a href="https://news.ycombinator.com/hide?id=16310117&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16310117">2&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16302720">
-      <td align="right" valign="top" class="title"><span class="rank">21.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16302720" href="https://news.ycombinator.com/vote?id=16302720&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="http://www.zdnet.com/article/meltdown-spectre-malware-is-already-being-tested-by-attackers/" class="storylink">Meltdown-Spectre: Malware is already being tested by attackers</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=zdnet.com"><span class="sitestr">zdnet.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16302720">114 points</span> by <a href="https://news.ycombinator.com/user?id=okket" class="hnuser">okket</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16302720">10 hours ago</a></span> <span id="unv_16302720"></span> | <a href="https://news.ycombinator.com/hide?id=16302720&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16302720">35&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16302062">
-      <td align="right" valign="top" class="title"><span class="rank">22.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16302062" href="https://news.ycombinator.com/vote?id=16302062&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://www.lrb.co.uk/v40/n03/bee-wilson/merely-a-warning-that-a-noun-is-coming" class="storylink">The Littlehampton libels</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=lrb.co.uk"><span class="sitestr">lrb.co.uk</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16302062">23 points</span> by <a href="https://news.ycombinator.com/user?id=tragic" class="hnuser">tragic</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16302062">4 hours ago</a></span> <span id="unv_16302062"></span> | <a href="https://news.ycombinator.com/hide?id=16302062&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16302062">1&nbsp;comment</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16302610">
-      <td align="right" valign="top" class="title"><span class="rank">23.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16302610" href="https://news.ycombinator.com/vote?id=16302610&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://www.newyorker.com/magazine/2018/02/05/customer-satisfaction-at-the-push-of-a-button" class="storylink" rel="nofollow">HappyOrNot terminals look simple, but the information they gather is revelatory</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=newyorker.com"><span class="sitestr">newyorker.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16302610">6 points</span> by <a href="https://news.ycombinator.com/user?id=aarghh" class="hnuser">aarghh</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16302610">1 hour ago</a></span> <span id="unv_16302610"></span> | <a href="https://news.ycombinator.com/hide?id=16302610&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16302610">discuss</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16308572">
-      <td align="right" valign="top" class="title"><span class="rank">24.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16308572" href="https://news.ycombinator.com/vote?id=16308572&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://www.huffingtonpost.com/entry/opinion-hari-depression-causes_us_5a6a144de4b0ddb658c46a21" class="storylink">Researching alternatives to the chemical imbalance theory of depression</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=huffingtonpost.com"><span class="sitestr">huffingtonpost.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16308572">14 points</span> by <a href="https://news.ycombinator.com/user?id=nradov" class="hnuser">nradov</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16308572">50 minutes ago</a></span> <span id="unv_16308572"></span> | <a href="https://news.ycombinator.com/hide?id=16308572&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16308572">5&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16300835">
-      <td align="right" valign="top" class="title"><span class="rank">25.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16300835" href="https://news.ycombinator.com/vote?id=16300835&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="http://esl.fis.edu/grammar/langdiff/korean.htm" class="storylink">The differences between English and Korean</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=fis.edu"><span class="sitestr">fis.edu</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16300835">30 points</span> by <a href="https://news.ycombinator.com/user?id=curtis" class="hnuser">curtis</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16300835">2 hours ago</a></span> <span id="unv_16300835"></span> | <a href="https://news.ycombinator.com/hide?id=16300835&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16300835">11&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16310455">
-      <td align="right" valign="top" class="title"><span class="rank">26.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16310455" href="https://news.ycombinator.com/vote?id=16310455&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="http://www.zdnet.com/article/open-source-turns-20/" class="storylink">​Open source is 20: How it changed programming and business forever</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=zdnet.com"><span class="sitestr">zdnet.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16310455">10 points</span> by <a href="https://news.ycombinator.com/user?id=CrankyBear" class="hnuser">CrankyBear</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16310455">44 minutes ago</a></span> <span id="unv_16310455"></span> | <a href="https://news.ycombinator.com/hide?id=16310455&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16310455">3&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16282001">
-      <td align="right" valign="top" class="title"><span class="rank">27.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16282001" href="https://news.ycombinator.com/vote?id=16282001&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://eli.thegreenplace.net/2018/return-type-polymorphism-in-haskell/" class="storylink">Return type polymorphism in Haskell</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=thegreenplace.net"><span class="sitestr">thegreenplace.net</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16282001">94 points</span> by <a href="https://news.ycombinator.com/user?id=osopanda" class="hnuser">osopanda</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16282001">12 hours ago</a></span> <span id="unv_16282001"></span> | <a href="https://news.ycombinator.com/hide?id=16282001&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16282001">54&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16306371">
-      <td align="right" valign="top" class="title"><span class="rank">28.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16306371" href="https://news.ycombinator.com/vote?id=16306371&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://medium.com/actualize-network/modern-css-explained-for-dinosaurs-5226febe3525" class="storylink">Modern CSS Explained</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=medium.com"><span class="sitestr">medium.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16306371">563 points</span> by <a href="https://news.ycombinator.com/user?id=MikusR" class="hnuser">MikusR</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16306371">15 hours ago</a></span> <span id="unv_16306371"></span> | <a href="https://news.ycombinator.com/hide?id=16306371&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16306371">104&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16302232">
-      <td align="right" valign="top" class="title"><span class="rank">29.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16302232" href="https://news.ycombinator.com/vote?id=16302232&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://medium.com/starts-with-a-bang/the-three-meanings-of-e-mc%C2%B2-einsteins-most-famous-equation-a0ec1549b4cd" class="storylink">Three Meanings of E=mc²</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=medium.com"><span class="sitestr">medium.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16302232">121 points</span> by <a href="https://news.ycombinator.com/user?id=LisaDziuba" class="hnuser">LisaDziuba</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16302232">12 hours ago</a></span> <span id="unv_16302232"></span> | <a href="https://news.ycombinator.com/hide?id=16302232&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16302232">36&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-                <tr class="athing" id="16308711">
-      <td align="right" valign="top" class="title"><span class="rank">30.</span></td>      <td valign="top" class="votelinks"><center><a id="up_16308711" href="https://news.ycombinator.com/vote?id=16308711&amp;how=up&amp;goto=news%3Fp%3D1"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://fstoppers.com/critiques/tale-two-moons-peter-liks-photographs-called-out-science-218194" class="storylink">A Tale of Two Moons: Peter Lik’s Photographs Called Out by Science</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=fstoppers.com"><span class="sitestr">fstoppers.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
-        <span class="score" id="score_16308711">75 points</span> by <a href="https://news.ycombinator.com/user?id=duck" class="hnuser">duck</a> <span class="age"><a href="https://news.ycombinator.com/item?id=16308711">4 hours ago</a></span> <span id="unv_16308711"></span> | <a href="https://news.ycombinator.com/hide?id=16308711&amp;goto=news%3Fp%3D1">hide</a> | <a href="https://news.ycombinator.com/item?id=16308711">35&nbsp;comments</a>              </td></tr>
-      <tr class="spacer" style="height:5px"></tr>
-            <tr class="morespace" style="height:10px"></tr><tr><td colspan="2"></td><td class="title"><a href="https://news.ycombinator.com/news?p=2" class="morelink" rel="nofollow">More</a></td></tr>
-  </tbody></table>
-</td></tr>
-<tr><td><img src="./test_files/s.gif" height="10" width="0"><table width="100%" cellspacing="0" cellpadding="1"><tbody><tr><td bgcolor="#ff6600"></td></tr></tbody></table><br><center><a href="https://www.ycombinator.com/apply/">
-        Applications are open for YC Summer 2018
-      </a></center><br><center><span class="yclinks"><a href="https://news.ycombinator.com/newsguidelines.html">Guidelines</a>
-        | <a href="https://news.ycombinator.com/newsfaq.html">FAQ</a>
-        | <a href="mailto:hn@ycombinator.com">Support</a>
-        | <a href="https://github.com/HackerNews/API">API</a>
-        | <a href="https://news.ycombinator.com/security.html">Security</a>
-        | <a href="https://news.ycombinator.com/lists">Lists</a>
-        | <a href="https://news.ycombinator.com/bookmarklet.html" rel="nofollow">Bookmarklet</a>
-        | <a href="https://news.ycombinator.com/dmca.html">DMCA</a>
-        | <a href="http://www.ycombinator.com/apply/">Apply to YC</a>
-        | <a href="mailto:hn@ycombinator.com">Contact</a></span><br><br><form method="get" action="https://hn.algolia.com/">Search:
-          <input type="text" name="q" value="" size="17" autocorrect="off" spellcheck="false" autocapitalize="off" autocomplete="false"></form>
-            </center></td></tr>      </tbody></table></center><script type="text/javascript" src="./test_files/hn.js"></script>
-  
-</body></html>
+<head>
+    <meta charset="UTF-8" /><title>Ang Nan - Wikipedia</title>
+    <script>document.documentElement.className = "client-js"; RLCONF = { "wgBreakFrames": false, "wgSeparatorTransformTable": ["", ""], "wgDigitTransformTable": ["", ""], "wgDefaultDateFormat": "dmy", "wgMonthNames": ["", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"], "wgRequestId": "2e4dda1f-9fac-495f-9999-8631965f6ce6", "wgCSPNonce": false, "wgCanonicalNamespace": "", "wgCanonicalSpecialPageName": false, "wgNamespaceNumber": 0, "wgPageName": "Ang_Nan", "wgTitle": "Ang Nan", "wgCurRevisionId": 1018803899, "wgRevisionId": 1018803899, "wgArticleId": 59327864, "wgIsArticle": true, "wgIsRedirect": false, "wgAction": "view", "wgUserName": null, "wgUserGroups": ["*"], "wgCategories": ["Articles lacking in-text citations from August 2020", "All articles lacking in-text citations", "Articles with short description", "Short description matches Wikidata", "Articles containing Khmer-language text", "1654 births", "1691 deaths", "17th-century Cambodian monarchs", "Monarchs who abdicated"], "wgPageContentLanguage": "en", "wgPageContentModel": "wikitext", "wgRelevantPageName": "Ang_Nan", "wgRelevantArticleId": 59327864, "wgIsProbablyEditable": true, "wgRelevantPageIsProbablyEditable": true, "wgRestrictionEdit": [], "wgRestrictionMove": [], "wgFlaggedRevsParams": { "tags": { "status": { "levels": -1 } } }, "wgPopupsFlags": 10, "wgVisualEditor": { "pageLanguageCode": "en", "pageLanguageDir": "ltr", "pageVariantFallbacks": "en" }, "wgMFDisplayWikibaseDescriptions": { "search": true, "nearby": true, "watchlist": true, "tagline": false }, "wgWMESchemaEditAttemptStepOversample": false, "wgWMEPageLength": 3000, "wgNoticeProject": "wikipedia", "wgMediaViewerOnClick": true, "wgMediaViewerEnabledByDefault": true, "wgULSCurrentAutonym": "English", "wgEditSubmitButtonLabelPublish": true, "wgCentralAuthMobileDomain": false, "wgULSPosition": "interlanguage", "wgULSisCompactLinksEnabled": true, "wgWikibaseItemId": "Q2849239", "wgGENewcomerTasksGuidanceEnabled": true, "wgGEAskQuestionEnabled": false, "wgGELinkRecommendationsFrontendEnabled": false }; RLSTATE = { "ext.globalCssJs.user.styles": "ready", "site.styles": "ready", "user.styles": "ready", "ext.globalCssJs.user": "ready", "user": "ready", "user.options": "loading", "ext.cite.styles": "ready", "skins.vector.styles.legacy": "ready", "jquery.makeCollapsible.styles": "ready", "ext.visualEditor.desktopArticleTarget.noscript": "ready", "ext.wikimediaBadges": "ready", "ext.uls.interlanguage": "ready", "wikibase.client.init": "ready" }; RLPAGEMODULES = ["ext.cite.ux-enhancements", "site", "mediawiki.page.ready", "jquery.makeCollapsible", "skins.vector.legacy.js", "ext.gadget.ReferenceTooltips", "ext.gadget.charinsert", "ext.gadget.extra-toolbar-buttons", "ext.gadget.refToolbar", "ext.gadget.switcher", "mmv.head", "mmv.bootstrap.autostart", "ext.popups", "ext.visualEditor.desktopArticleTarget.init", "ext.visualEditor.targetLoader", "ext.eventLogging", "ext.wikimediaEvents", "ext.navigationTiming", "ext.cx.eventlogging.campaigns", "ext.centralNotice.geoIP", "ext.centralNotice.startUp", "ext.centralauth.centralautologin", "ext.uls.compactlinks", "ext.uls.interface", "ext.growthExperiments.SuggestedEditSession"];</script>
+    <script>(RLQ = window.RLQ || []).push(function () { mw.loader.implement("user.options@1hzgi", function ($, jQuery, require, module) { mw.user.tokens.set({ "patrolToken": "+\\\\", "watchToken": "+\\\\", "csrfToken": "+\\\\" }); }); });</script>
+    
+    <link rel="stylesheet"
+        href="/w/load.php?lang=en&amp;modules=ext.cite.styles%7Cext.uls.interlanguage%7Cext.visualEditor.desktopArticleTarget.noscript%7Cext.wikimediaBadges%7Cjquery.makeCollapsible.styles%7Cskins.vector.styles.legacy%7Cwikibase.client.init&amp;only=styles&amp;skin=vector" />
+    
+    <script async="" src="/w/load.php?lang=en&amp;modules=startup&amp;only=scripts&amp;raw=1&amp;skin=vector"></script>
+    
+    <meta name="ResourceLoaderDynamicStyles" content="" />
+    <link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=site.styles&amp;only=styles&amp;skin=vector" />
+    <meta name="generator" content="MediaWiki 1.38.0-wmf.13" />
+    <meta name="referrer" content="origin" />
+    <meta name="referrer" content="origin-when-crossorigin" />
+    <meta name="referrer" content="origin-when-cross-origin" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta property="og:title" content="Ang Nan - Wikipedia" />
+    <meta property="og:type" content="website" />
+    <link rel="preconnect" href="//upload.wikimedia.org" />
+    <link rel="alternate" media="only screen and (max-width: 720px)" href="//en.m.wikipedia.org/wiki/Ang_Nan" />
+    <link rel="alternate" type="application/x-wiki" title="Edit this page"
+        href="/w/index.php?title=Ang_Nan&amp;action=edit" />
+    <link rel="apple-touch-icon" href="/static/apple-touch/wikipedia.png" />
+    <link rel="shortcut icon" href="/static/favicon/wikipedia.ico" />
+    <link rel="search" type="application/opensearchdescription+xml" href="/w/opensearch_desc.php"
+        title="Wikipedia (en)" />
+    <link rel="EditURI" type="application/rsd+xml" href="//en.wikipedia.org/w/api.php?action=rsd" />
+    <link rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" />
+    <link rel="canonical" href="https://en.wikipedia.org/wiki/Ang_Nan" />
+    <link rel="dns-prefetch" href="//meta.wikimedia.org" />
+    <link rel="dns-prefetch" href="//login.wikimedia.org" />
+</head>
+
+<body
+    class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable page-Ang_Nan rootpage-Ang_Nan skin-vector action-view skin-vector-legacy">
+    <div id="mw-page-base" class="noprint"></div><div id="mw-head-base" class="noprint"></div><div id="content"
+        class="mw-body" role="main">\t<a id="top"></a>\t<div id="siteNotice">
+            <!-- CentralNotice -->
+        </div>\t<div class="mw-indicators">\t</div>\t<h1 id="firstHeading" class="firstHeading">Ang Nan</h1>\t
+        <div id="bodyContent" class="vector-body">\t\t<div id="siteSub" class="noprint">From Wikipedia, the free
+                encyclopedia</div>\t\t<div id="contentSub"></div>\t\t<div id="contentSub2"></div>\t\t\t\t<div
+                id="jump-to-nav"></div>\t\t<a class="mw-jump-link" href="#mw-head">Jump to navigation</a>\t\t<a
+                class="mw-jump-link" href="#searchInput">Jump to search</a>\t\t<div id="mw-content-text"
+                class="mw-body-content mw-content-ltr" lang="en" dir="ltr">
+                <div class="mw-parser-output">
+                    <table class="box-More_footnotes plainlinks metadata ambox ambox-style ambox-More_footnotes"
+                        role="presentation">
+                        <tbody>
+                            <tr>
+                                <td class="mbox-image">
+                                    <div style="width:52px"><img alt=""
+                                            src="//upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Text_document_with_red_question_mark.svg/40px-Text_document_with_red_question_mark.svg.png"
+                                            decoding="async" width="40" height="40"
+                                            srcset="//upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Text_document_with_red_question_mark.svg/60px-Text_document_with_red_question_mark.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Text_document_with_red_question_mark.svg/80px-Text_document_with_red_question_mark.svg.png 2x"
+                                            data-file-width="48" data-file-height="48" /></div>
+                                </td>
+                                <td class="mbox-text">
+                                    <div class="mbox-text-span">This article includes a list of general <a
+                                            href="/wiki/Wikipedia:Citing_sources"
+                                            title="Wikipedia:Citing sources">references</a>, but it remains largely
+                                        unverified because <b>it lacks sufficient corresponding <a
+                                                href="/wiki/Wikipedia:Citing_sources#Inline_citations"
+                                                title="Wikipedia:Citing sources">inline citations</a></b>.<span
+                                            class="hide-when-compact"> Please help to <a
+                                                href="/wiki/Wikipedia:WikiProject_Fact_and_Reference_Check"
+                                                class="mw-redirect"
+                                                title="Wikipedia:WikiProject Fact and Reference Check">improve</a> this
+                                            article by <a href="/wiki/Wikipedia:When_to_cite"
+                                                title="Wikipedia:When to cite">introducing</a> more precise
+                                            citations.</span> <span class="date-container"><i>(<span class="date">August
+                                                    2020</span>)</i></span><span class="hide-when-compact"><i> (<a
+                                                    href="/wiki/Help:Maintenance_template_removal"
+                                                    title="Help:Maintenance template removal">Learn how and when to
+                                                    remove this template message</a>)</i></span></div>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table><div class="shortdescription nomobile noexcerpt noprint searchaux" style="display:none">
+                        King of Cambodia</div><div class="shortdescription nomobile noexcerpt noprint searchaux"
+                        style="display:none">King of Cambodia</div><style
+                        data-mw-deduplicate="TemplateStyles:r1048617464">
+                        .mw-parser-output .infobox-subbox {
+                            padding: 0;
+                            border: none;
+                            margin: -3px;
+                            width: auto;
+                            min-width: 100%;
+                            font-size: 100%;
+                            clear: none;
+                            float: none;
+                            background-color: transparent
+                        }
+
+                        .mw-parser-output .infobox-3cols-child {
+                            margin: auto
+                        }
+                    </style>
+                    <table class="infobox vcard">
+                        <tbody>
+                            <tr>
+                                <th colspan="2" class="infobox-above fn"
+                                    style="background-color: #cbe; font-size: 125%">Batom Reachea III <br />
+                                    \u1794\u1791\u17bb\u1798\u179a\u17b6\u1787\u17b6\u1791\u17b8\u17e3</th>
+                            </tr>
+                            <tr>
+                                <td colspan="2" class="infobox-subheader"><i>King of Cambodia</i></td>
+                            </tr>
+                            <tr>
+                                <th colspan="2" class="infobox-header"
+                                    style="background-color: #e4dcf6;line-height:normal;padding:0.2em 0.2em"><a
+                                        href="/wiki/List_of_kings_of_Cambodia" class="mw-redirect"
+                                        title="List of kings of Cambodia">King of Cambodia</a></th>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="infobox-label">Reign</th>
+                                <td class="infobox-data">1674</td>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="infobox-label">Predecessor</th>
+                                <td class="infobox-data"><a href="/wiki/Kaev_Hua_II" title="Kaev Hua II">Preah Keo
+                                        II</a></td>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="infobox-label">Successor</th>
+                                <td class="infobox-data"><a href="/wiki/Chey_Chettha_IV" title="Chey Chettha IV">Chey
+                                        Chettha IV</a></td>
+                            </tr>
+                            <tr>
+                                <th colspan="2" class="infobox-header"
+                                    style="background-color: #e4dcf6;line-height:normal;padding:0.2em 0.2em"><a
+                                        href="/wiki/List_of_kings_of_Cambodia" class="mw-redirect"
+                                        title="List of kings of Cambodia">Vice King of Cambodia</a></th>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="infobox-label">Reign</th>
+                                <td class="infobox-data">1682\u20131689</td>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="infobox-label">Predecessor</th>
+                                <td class="infobox-data">Outey</td>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="infobox-label">Successor</th>
+                                <td class="infobox-data"><a href="/wiki/Ang_Em" title="Ang Em">Ang Em</a></td>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="infobox-label"><a href="/wiki/List_of_kings_of_Cambodia"
+                                        class="mw-redirect" title="List of kings of Cambodia">King</a></th>
+                                <td class="infobox-data"><a href="/wiki/Chey_Chettha_IV" title="Chey Chettha IV">Chey
+                                        Chettha IV</a></td>
+                            </tr>
+                            <tr>
+                                <th colspan="2" class="infobox-header"
+                                    style="background-color: #e4dcf6;line-height:normal;padding:0.2em 0.2em">
+                                    <div style="height: 4px; width:100%;"></div>
+                                </th>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="infobox-label">Born</th>
+                                <td class="infobox-data">Ang Nan<br />1654</td>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="infobox-label">Died</th>
+                                <td class="infobox-data">1691<br /><a href="/wiki/Srey_Santhor_District"
+                                        title="Srey Santhor District">Srey Santhor</a>, <a href="/wiki/Cambodia"
+                                        title="Cambodia">Cambodia</a></td>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="infobox-label">Spouse</th>
+                                <td class="infobox-data">Sri Thida</td>
+                            </tr>
+                            <tr>
+                                <td colspan="2" class="infobox-full-data">
+                                    <link rel="mw-deduplicated-inline-style"
+                                        href="mw-data:TemplateStyles:r1048617464" />
+                                    <table class="infobox"
+                                        style="border-collapse:collapse; border-spacing:0px; border:none; width:100%; margin:0px; font-size:100%; clear:none; float:none">
+                                        <tbody>
+                                            <tr>
+                                                <th colspan="2" class="infobox-header" style="text-align:left">Names
+                                                </th>
+                                            </tr>
+                                            <tr>
+                                                <td colspan="2" class="infobox-full-data nickname"
+                                                    style="text-align:left; padding-left:0.7em;">Preah Bat Samdech Batom
+                                                    Reachea III</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="infobox-label"><a href="/wiki/Dynasty" title="Dynasty">House</a>
+                                </th>
+                                <td class="infobox-data"><a href="/wiki/List_of_monarchs_of_Cambodia"
+                                        class="mw-redirect" title="List of monarchs of Cambodia">Varman Dynasty</a></td>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="infobox-label">Father</th>
+                                <td class="infobox-data">Ang Im</td>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="infobox-label">Religion</th>
+                                <td class="infobox-data"><a href="/wiki/Buddhism" title="Buddhism">Buddhism</a></td>
+                            </tr>
+                        </tbody>
+                    </table><p><b>Batom Reachea III</b> (<a href="/wiki/Khmer_language"
+                            title="Khmer language">Khmer</a>: <span
+                            lang="km">\u1794\u1791\u17bb\u1798\u179a\u17b6\u1787\u17b6\u1791\u17b8\u17e3</span>, born
+                        <b>Ang Nan</b>; 1654&#8211;1691) was a <a href="/wiki/Cambodia" title="Cambodia">Cambodian</a>
+                        vice king (<a href="/wiki/Uparaja" title="Uparaja">uparaja</a>) from 1682 to 1689.</p>
+                    <p>Ang Nan was the grandson of vice king <a href="/wiki/Outey" title="Outey">Outey</a>. In 1674,
+                        with the help of the <a href="/wiki/Ayutthaya_Kingdom" title="Ayutthaya Kingdom">Ayutthaya
+                            Kingdom</a>, <a href="/wiki/Kaev_Hua_II" title="Kaev Hua II">Preah Keo II</a> drove him out.
+                        Ang Nan fled to Th\xe1i Khang (present day <a href="/wiki/Kh%C3%A1nh_H%C3%B2a_Province"
+                            class="mw-redirect" title="Kh\xe1nh H\xf2a Province">Kh\xe1nh H\xf2a Province</a> of
+                        Vietnam), and sought help from Vietnamese <a href="/wiki/Nguy%E1%BB%85n_lord"
+                            class="mw-redirect" title="Nguy\u1ec5n lord">Nguy\u1ec5n lord</a>. The Vietnamese army under
+                        <a href="/w/index.php?title=Nguy%E1%BB%85n_D%C6%B0%C6%A1ng_L%C3%A2m&amp;action=edit&amp;redlink=1"
+                            class="new" title="Nguy\u1ec5n D\u01b0\u01a1ng L\xe2m (page does not exist)">Nguy\u1ec5n
+                            D\u01b0\u01a1ng L\xe2m</a> (\u962e\u694a\u6797) and <a
+                            href="/w/index.php?title=Nguy%E1%BB%85n_%C4%90%C3%ACnh_Ph%C3%A1i&amp;action=edit&amp;redlink=1"
+                            class="new" title="Nguy\u1ec5n \u0110\xecnh Ph\xe1i (page does not exist)">Nguy\u1ec5n
+                            \u0110\xecnh Ph\xe1i</a> (\u962e\u5ef7\u6d3e) invaded Cambodia, captured Prey Nokor (<a
+                            href="/wiki/Saigon" class="mw-redirect" title="Saigon">Saigon</a>), then attacked <a
+                            href="/wiki/Phnom_Penh" title="Phnom Penh">Phnom Penh</a>. Preah Keo II retreated into the
+                        forest and Ang Nan was crowned the vice king (<a href="/wiki/Uparaja"
+                            title="Uparaja">uparaja</a>) by the Vietnamese. Ang Nan occupied Prey Nokor, while king <a
+                            href="/wiki/Chey_Chettha_IV" title="Chey Chettha IV">Chey Chettha IV</a> occupied <a
+                            href="/wiki/Longvek" title="Longvek">Longvek</a>. Both of them paid tribute to Nguy\u1ec5n
+                        lord every year.<sup id="cite_ref-suluoc6_1-0" class="reference"><a
+                                href="#cite_note-suluoc6-1">&#91;1&#93;</a></sup></p>
+                    <p>However, Ang Nan wanted to overthrow Chey Chettha IV. In 1682, he recruited refugees from <a
+                            href="/wiki/Ming_China" class="mw-redirect" title="Ming China">Ming China</a> who had
+                        settled in Cambodia with Vietnamese immigrants, resumed fighting against Chey Chettha IV. In
+                        response, Kau Kan (Bassac, present day <a href="/wiki/S%C3%B3c_Tr%C4%83ng"
+                            title="S\xf3c Tr\u0103ng">S\xf3c Tr\u0103ng</a>) and Preah Trapeang (<a
+                            href="/wiki/Tr%C3%A0_Vinh" title="Tr\xe0 Vinh">Tr\xe0 Vinh</a>) were ceded to these Chinese
+                        adventures. In 1689, with the help of the Nguy\u1ec5n lord, he made his last attempt to
+                        overthrow Chey Chettha IV. He died in <a href="/wiki/Srey_Santhor_District"
+                            title="Srey Santhor District">Srey Santhor</a>.</p><h2><span class="mw-headline"
+                            id="References">References</span><span class="mw-editsection"><span
+                                class="mw-editsection-bracket">[</span><a
+                                href="/w/index.php?title=Ang_Nan&amp;action=edit&amp;section=1"
+                                title="Edit section: References">edit</a><span
+                                class="mw-editsection-bracket">]</span></span></h2><style
+                        data-mw-deduplicate="TemplateStyles:r1011085734">
+                        .mw-parser-output .reflist {
+                            font-size: 90%;
+                            margin-bottom: 0.5em;
+                            list-style-type: decimal
+                        }
+
+                        .mw-parser-output .reflist .references {
+                            font-size: 100%;
+                            margin-bottom: 0;
+                            list-style-type: inherit
+                        }
+
+                        .mw-parser-output .reflist-columns-2 {
+                            column-width: 30em
+                        }
+
+                        .mw-parser-output .reflist-columns-3 {
+                            column-width: 25em
+                        }
+
+                        .mw-parser-output .reflist-columns {
+                            margin-top: 0.3em
+                        }
+
+                        .mw-parser-output .reflist-columns ol {
+                            margin-top: 0
+                        }
+
+                        .mw-parser-output .reflist-columns li {
+                            page-break-inside: avoid;
+                            break-inside: avoid-column
+                        }
+
+                        .mw-parser-output .reflist-upper-alpha {
+                            list-style-type: upper-alpha
+                        }
+
+                        .mw-parser-output .reflist-upper-roman {
+                            list-style-type: upper-roman
+                        }
+
+                        .mw-parser-output .reflist-lower-alpha {
+                            list-style-type: lower-alpha
+                        }
+
+                        .mw-parser-output .reflist-lower-greek {
+                            list-style-type: lower-greek
+                        }
+
+                        .mw-parser-output .reflist-lower-roman {
+                            list-style-type: lower-roman
+                        }
+                    </style>
+                    <div class="reflist"><div class="mw-references-wrap">
+                            <ol class="references"><li id="cite_note-suluoc6-1"><span class="mw-cite-backlink"><b><a
+                                                href="#cite_ref-suluoc6_1-0">^</a></b></span> <span
+                                        class="reference-text"><i><a
+                                                href="/wiki/Vi%E1%BB%87t_Nam_s%E1%BB%AD_l%C6%B0%E1%BB%A3c"
+                                                title="Vi\u1ec7t Nam s\u1eed l\u01b0\u1ee3c">Vi\u1ec7t Nam s\u1eed
+                                                l\u01b0\u1ee3c</a></i>, <a
+                                            href="https://en.wikisource.org/wiki/vi:Vi%E1%BB%87t_Nam_s%E1%BB%AD_l%C6%B0%E1%BB%A3c/Quy%E1%BB%83n_II/T%E1%BB%B1_ch%E1%BB%A7_th%E1%BB%9Di_%C4%91%E1%BA%A1i/Ch%C6%B0%C6%A1ng_VI"
+                                            class="extiw"
+                                            title="s:vi:Vi\u1ec7t Nam s\u1eed l\u01b0\u1ee3c/Quy\u1ec3n II/T\u1ef1 ch\u1ee7 th\u1eddi \u0111\u1ea1i/Ch\u01b0\u01a1ng VI">Quy\u1ec3n
+                                            2, T\u1ef1 ch\u1ee7 th\u1eddi \u0111\u1ea1i, Ch\u01b0\u01a1ng 6</a></span>
+                                </li></ol>
+                        </div>
+                    </div><ul>
+                        <li>Phoeun Mak, Dharma Po. \xab&#160;La deuxi\xe8me intervention militaire vietnamienne au
+                            Cambodge (1673-1679)&#160;\xbb dans: <i><a
+                                    href="/wiki/Bulletin_de_l%27%C3%89cole_fran%C3%A7aise_d%27Extr%C3%AAme-Orient"
+                                    class="mw-redirect"
+                                    title="Bulletin de l&#39;\xc9cole fran\xe7aise d&#39;Extr\xeame-Orient">Bulletin de
+                                    l\'\xc9cole fran\xe7aise d\'Extr\xeame-Orient</a></i>. Tome 77, 1988.
+                            p.&#160;229-262.</li><li>Phoen Mak, Dharma Po. \xab&#160;La troisi\xe8me intervention
+                            vietnamienne au Cambodge (1679-1688)&#160;\xbb Dans: <i><a
+                                    href="/wiki/Bulletin_de_l%27%C3%89cole_fran%C3%A7aise_d%27Extr%C3%AAme-Orient"
+                                    class="mw-redirect"
+                                    title="Bulletin de l&#39;\xc9cole fran\xe7aise d&#39;Extr\xeame-Orient">Bulletin de
+                                    l\'\xc9cole fran\xe7aise d\'Extr\xeame-Orient</a></i>. Tome 92, 2005.
+                            p.&#160;339-381.</li><li>A. Dauphin-Meunier <i>Histoire du Cambodge</i> P.U.F Paris 1968.
+                        </li>
+                    </ul><table class="wikitable succession-box noprint"
+                        style="margin:0.5em auto; font-size:95%;clear:both;"><tbody>
+                            <tr><td colspan="3" style="border-top: 5px solid #FFD700; text-align:center;">
+                                    <div>Ang Nan </div>
+                                    <div><b>Varman Dynasty</b></div><span
+                                        style="white-space:nowrap; font-size:90%; margin:2em"><b>Born:</b>
+                                        1654</span><span
+                                        style="white-space:nowrap; font-size:90%; margin:2em">&#160;<b>Died:</b>
+                                        1691</span>
+                                </td>
+                            </tr><tr><th colspan="3" style="border-top: 5px solid #ACE777;">Regnal titles</th>
+                            </tr><tr style="text-align:center;"><td style="width:30%;" rowspan="1">Preceded&#160;by
+                                    <div style="font-weight: bold"><a href="/wiki/Kaev_Hua_II" title="Kaev Hua II">Kaev
+                                            Hua II</a></div></td><td style="width: 40%; text-align: center;"
+                                    rowspan="1"><b> <a href="/wiki/List_of_kings_of_Cambodia" class="mw-redirect"
+                                            title="List of kings of Cambodia">King of Cambodia</a> </b><br />1674</td>
+                                <td style="width: 30%; text-align: center;" rowspan="1">Succeeded&#160;by<div
+                                        style="font-weight: bold"><a href="/wiki/Chey_Chettha_IV"
+                                            title="Chey Chettha IV">Chey Chettha IV</a></div></td>
+                            </tr>
+                        </tbody>
+                    </table><div class="navbox-styles nomobile">
+                        <style data-mw-deduplicate="TemplateStyles:r1057682214">
+                            .mw-parser-output .navbox {
+                                box-sizing: border-box;
+                                border: 1px solid #a2a9b1;
+                                width: 100%;
+                                clear: both;
+                                font-size: 88%;
+                                text-align: center;
+                                padding: 1px;
+                                margin: 1em auto 0
+                            }
+
+                            .mw-parser-output .navbox .navbox {
+                                margin-top: 0
+                            }
+
+                            .mw-parser-output .navbox+.navbox,
+                            .mw-parser-output .navbox+.navbox-styles+.navbox {
+                                margin-top: -1px
+                            }
+
+                            .mw-parser-output .navbox-inner,
+                            .mw-parser-output .navbox-subgroup {
+                                width: 100%
+                            }
+
+                            .mw-parser-output .navbox-group,
+                            .mw-parser-output .navbox-title,
+                            .mw-parser-output .navbox-abovebelow {
+                                padding: 0.25em 1em;
+                                line-height: 1.5em;
+                                text-align: center
+                            }
+
+                            .mw-parser-output .navbox-group {
+                                white-space: nowrap;
+                                text-align: right
+                            }
+
+                            .mw-parser-output .navbox,
+                            .mw-parser-output .navbox-subgroup {
+                                background-color: #fdfdfd
+                            }
+
+                            .mw-parser-output .navbox-list {
+                                line-height: 1.5em;
+                                border-color: #fdfdfd
+                            }
+
+                            .mw-parser-output .navbox-list-with-group {
+                                text-align: left;
+                                border-left-width: 2px;
+                                border-left-style: solid
+                            }
+
+                            .mw-parser-output tr+tr>.navbox-abovebelow,
+                            .mw-parser-output tr+tr>.navbox-group,
+                            .mw-parser-output tr+tr>.navbox-image,
+                            .mw-parser-output tr+tr>.navbox-list {
+                                border-top: 2px solid #fdfdfd
+                            }
+
+                            .mw-parser-output .navbox th,
+                            .mw-parser-output .navbox-title {}
+
+                            .mw-parser-output .navbox-abovebelow,
+                            .mw-parser-output th.navbox-group,
+                            .mw-parser-output .navbox-subgroup .navbox-title {
+                                background-color: #ddf
+                            }
+
+                            .mw-parser-output .navbox-subgroup .navbox-group,
+                            .mw-parser-output .navbox-subgroup .navbox-abovebelow {
+                                background-color: #e6e6ff
+                            }
+
+                            .mw-parser-output .navbox-even {
+                                background-color: #f7f7f7
+                            }
+
+                            .mw-parser-output .navbox-odd {
+                                background-color: transparent
+                            }
+
+                            .mw-parser-output .navbox .hlist td dl,
+                            .mw-parser-output .navbox .hlist td ol,
+                            .mw-parser-output .navbox .hlist td ul,
+                            .mw-parser-output .navbox td.hlist dl,
+                            .mw-parser-output .navbox td.hlist ol,
+                            .mw-parser-output .navbox td.hlist ul {
+                                padding: 0.125em 0
+                            }
+
+                            .mw-parser-output .navbox .navbar {
+                                display: block;
+                                font-size: 100%
+                            }
+
+                            .mw-parser-output .navbox-title .navbar {
+                                float: left;
+                                text-align: left;
+                                margin-right: 0.5em
+                            }
+                        </style>
+                    </div>
+                    <div role="navigation" class="navbox" aria-labelledby="Monarchs_of_Cambodia" style="padding:3px">
+                        <table class="nowraplinks mw-collapsible mw-collapsed navbox-inner"
+                            style="border-spacing:0;background:transparent;color:inherit">
+                            <tbody>
+                                <tr>
+                                    <th scope="col" class="navbox-title" colspan="2"
+                                        style="background:white; color:black; box-shadow: inset 2px 2px 0 #F0DC82, inset -2px -2px 0 #F0DC82;;border:1px; background: #F0DC82">
+                                        <style data-mw-deduplicate="TemplateStyles:r1054937957">
+                                            .mw-parser-output .navbar {
+                                                display: inline;
+                                                font-size: 88%;
+                                                font-weight: normal
+                                            }
+
+                                            .mw-parser-output .navbar-collapse {
+                                                float: left;
+                                                text-align: left
+                                            }
+
+                                            .mw-parser-output .navbar-boxtext {
+                                                word-spacing: 0
+                                            }
+
+                                            .mw-parser-output .navbar ul {
+                                                display: inline-block;
+                                                white-space: nowrap;
+                                                line-height: inherit
+                                            }
+
+                                            .mw-parser-output .navbar-brackets::before {
+                                                margin-right: -0.125em;
+                                                content: "[ "
+                                            }
+
+                                            .mw-parser-output .navbar-brackets::after {
+                                                margin-left: -0.125em;
+                                                content: " ]"
+                                            }
+
+                                            .mw-parser-output .navbar li {
+                                                word-spacing: -0.125em
+                                            }
+
+                                            .mw-parser-output .navbar a>span,
+                                            .mw-parser-output .navbar a>abbr {
+                                                text-decoration: inherit
+                                            }
+
+                                            .mw-parser-output .navbar-mini abbr {
+                                                font-variant: small-caps;
+                                                border-bottom: none;
+                                                text-decoration: none;
+                                                cursor: inherit
+                                            }
+
+                                            .mw-parser-output .navbar-ct-full {
+                                                font-size: 114%;
+                                                margin: 0 7em
+                                            }
+
+                                            .mw-parser-output .navbar-ct-mini {
+                                                font-size: 114%;
+                                                margin: 0 4em
+                                            }
+
+                                            .mw-parser-output .infobox .navbar {
+                                                font-size: 100%
+                                            }
+
+                                            .mw-parser-output .navbox .navbar {
+                                                display: block;
+                                                font-size: 100%
+                                            }
+
+                                            .mw-parser-output .navbox-title .navbar {
+                                                float: left;
+                                                text-align: left;
+                                                margin-right: 0.5em
+                                            }
+                                        </style>
+                                        <div class="navbar plainlinks hlist navbar-mini">
+                                            <ul>
+                                                <li class="nv-view"><a href="/wiki/Template:Monarchs_of_Cambodia"
+                                                        title="Template:Monarchs of Cambodia"><abbr
+                                                            title="View this template"
+                                                            style="background:white; color:black; box-shadow: inset 2px 2px 0 #F0DC82, inset -2px -2px 0 #F0DC82;;border:1px; background: #F0DC82;background:none transparent;border:none;box-shadow:none;padding:0;">v</abbr></a>
+                                                </li>
+                                                <li class="nv-talk"><a href="/wiki/Template_talk:Monarchs_of_Cambodia"
+                                                        title="Template talk:Monarchs of Cambodia"><abbr
+                                                            title="Discuss this template"
+                                                            style="background:white; color:black; box-shadow: inset 2px 2px 0 #F0DC82, inset -2px -2px 0 #F0DC82;;border:1px; background: #F0DC82;background:none transparent;border:none;box-shadow:none;padding:0;">t</abbr></a>
+                                                </li>
+                                                <li class="nv-edit"><a class="external text"
+                                                        href="https://en.wikipedia.org/w/index.php?title=Template:Monarchs_of_Cambodia&amp;action=edit"><abbr
+                                                            title="Edit this template"
+                                                            style="background:white; color:black; box-shadow: inset 2px 2px 0 #F0DC82, inset -2px -2px 0 #F0DC82;;border:1px; background: #F0DC82;background:none transparent;border:none;box-shadow:none;padding:0;">e</abbr></a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                        <div id="Monarchs_of_Cambodia" style="font-size:114%;margin:0 4em"><a
+                                                href="/wiki/Monarchy_of_Cambodia"
+                                                title="Monarchy of Cambodia">Monarchs</a> of <a href="/wiki/Cambodia"
+                                                title="Cambodia">Cambodia</a></div>
+                                    </th>
+                                </tr>
+                                <tr>
+                                    <td class="navbox-abovebelow" colspan="2"
+                                        style="background:white; color:black; box-shadow: inset 2px 2px 0 #F0DC82, inset -2px -2px 0 #F0DC82;">
+                                        <div id="Cambodian_monarchs&amp;#039;_family_tree"><a
+                                                href="/wiki/Cambodian_monarchs%27_family_tree" class="mw-redirect"
+                                                title="Cambodian monarchs&#39; family tree">Cambodian monarchs\' family
+                                                tree</a></div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="navbox-group"
+                                        style="background:white; color:black; box-shadow: inset 2px 2px 0 #F0DC82, inset -2px -2px 0 #F0DC82;;width:1%">
+                                        <a href="/wiki/Funan" title="Funan">Funan Kingdom</a><br />Nokor Phnom</th>
+                                    <td class="navbox-list-with-group navbox-list navbox-odd hlist"
+                                        style="width:100%;padding:0">
+                                        <div style="padding:0 0.25em"><ul>
+                                                <li><a href="/wiki/Queen_Soma" title="Queen Soma">Soma</a> (Neang Neak)
+                                                    <span style="font-size:85%;">(female)</span></li><li><a
+                                                        href="/wiki/Kaundinya_I" title="Kaundinya I">Kaundinya I</a>
+                                                    (Preah Tong)</li><li><a
+                                                        href="/w/index.php?title=Hun_Pan-huang&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Hun Pan-huang (page does not exist)">Hun
+                                                        Pan-huang</a></li><li><a
+                                                        href="/w/index.php?title=Pan-Pan&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Pan-Pan (page does not exist)">Pan-Pan</a>
+                                                </li><li><a
+                                                        href="/w/index.php?title=Srei_Meara&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Srei Meara (page does not exist)">Srei Meara
+                                                        (Fan Shiman)</a></li><li><a
+                                                        href="/w/index.php?title=Fan_Jinsheng&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Fan Jinsheng (page does not exist)">Fan
+                                                        Jinsheng</a></li><li><a
+                                                        href="/w/index.php?title=Fan_Chang&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Fan Chang (page does not exist)">Fan
+                                                        Chang</a></li><li><a
+                                                        href="/w/index.php?title=Fan_Xun&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Fan Xun (page does not exist)">Fan Xun</a>
+                                                </li><li><a
+                                                        href="/w/index.php?title=Kaundinya_II&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Kaundinya II (page does not exist)">Kaundinya
+                                                        II</a></li><li><a
+                                                        href="/w/index.php?title=Sri_Indravarman_I&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Sri Indravarman I (page does not exist)">Sri
+                                                        Indravarman I</a></li><li><a href="/wiki/Jayavarman_Kaundinya"
+                                                        title="Jayavarman Kaundinya">Jayavarman Kaundinya</a></li><li>
+                                                    <a href="/wiki/Kulaprabhavati"
+                                                        title="Kulaprabhavati">Kulaprabhavati</a> <span
+                                                        style="font-size:85%;">(female)</span></li><li><a
+                                                        href="/wiki/Rudravarman" title="Rudravarman">Rudravarman</a>
+                                                </li><li><a
+                                                        href="/w/index.php?title=Pvirakvarman_I&amp;action=edit&amp;redlink=1"
+                                                        class="new"
+                                                        title="Pvirakvarman I (page does not exist)">Pvirakvarman I</a>
+                                                </li><li><a
+                                                        href="/w/index.php?title=Mhenteractvarman_I&amp;action=edit&amp;redlink=1"
+                                                        class="new"
+                                                        title="Mhenteractvarman I (page does not exist)">Mhenteractvarman
+                                                        I</a></li><li><a
+                                                        href="/w/index.php?title=Nteractvarman_I&amp;action=edit&amp;redlink=1"
+                                                        class="new"
+                                                        title="Nteractvarman I (page does not exist)">Nteractvarman
+                                                        I</a></li>
+                                            </ul></div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="navbox-group"
+                                        style="background:white; color:black; box-shadow: inset 2px 2px 0 #F0DC82, inset -2px -2px 0 #F0DC82;;width:1%">
+                                        <a href="/wiki/Chenla" title="Chenla">Chenla Kingdom</a></th>
+                                    <td class="navbox-list-with-group navbox-list navbox-even hlist"
+                                        style="width:100%;padding:0">
+                                        <div style="padding:0 0.25em"><ul>
+                                                <li><a href="/w/index.php?title=Shruta_Varman&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Shruta Varman (page does not exist)">Shruta
+                                                        Varman</a></li><li><a
+                                                        href="/w/index.php?title=Shreshtha_Varman_II&amp;action=edit&amp;redlink=1"
+                                                        class="new"
+                                                        title="Shreshtha Varman II (page does not exist)">Shreshtha
+                                                        Varman II</a></li><li><a
+                                                        href="/w/index.php?title=Vira_Varman&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Vira Varman (page does not exist)">Vira
+                                                        Varman</a></li><li><a href="/wiki/Bhavavarman_I"
+                                                        title="Bhavavarman I">Bhavavarman I</a></li><li><a
+                                                        href="/wiki/Mahendravarman_(Chenla)"
+                                                        title="Mahendravarman (Chenla)">Mohendravarman</a></li><li><a
+                                                        href="/wiki/Isanavarman_I" title="Isanavarman I">Isanavarman
+                                                        I</a></li><li><a
+                                                        href="/w/index.php?title=Bhavavarman_II&amp;action=edit&amp;redlink=1"
+                                                        class="new"
+                                                        title="Bhavavarman II (page does not exist)">Bhavavarman II</a>
+                                                </li><li><a href="/wiki/Jayavarman_I" title="Jayavarman I">Jayavarman
+                                                        I</a></li><li><a href="/wiki/Jayadevi"
+                                                        title="Jayadevi">Jayadevi</a> <span
+                                                        style="font-size:85%;">(female)</span></li><li><a
+                                                        href="/w/index.php?title=Pushkaraksha&amp;action=edit&amp;redlink=1"
+                                                        class="new"
+                                                        title="Pushkaraksha (page does not exist)">Pushkaraksha</a></li>
+                                                <li><a href="/wiki/Indrani_of_Sambhupura"
+                                                        title="Indrani of Sambhupura">Indrani</a> <span
+                                                        style="font-size:85%;">(female)</span></li><li><a
+                                                        href="/wiki/N%E1%B9%9Bpatendradev%C4%AB" class="mw-redirect"
+                                                        title="N\u1e5bpatendradev\u012b">N\u1e5bpatendradev\u012b</a>
+                                                    <span style="font-size:85%;">(female)</span></li><li><a
+                                                        href="/wiki/Jayendrabh%C4%81" class="mw-redirect"
+                                                        title="Jayendrabh\u0101">Jayendrabh\u0101</a> <span
+                                                        style="font-size:85%;">(female)</span></li><li><a
+                                                        href="/wiki/Jye%E1%B9%A3%E1%B9%ADh%C4%81ry%C4%81"
+                                                        class="mw-redirect"
+                                                        title="Jye\u1e63\u1e6dh\u0101ry\u0101">Jye\u1e63\u1e6dh\u0101ry\u0101</a>
+                                                    <span style="font-size:85%;">(female)</span></li><li><a
+                                                        href="/w/index.php?title=Shambhu_Varman&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Shambhu Varman (page does not exist)">Shambhu
+                                                        Varman</a></li><li><a
+                                                        href="/w/index.php?title=Rajendravarman_I&amp;action=edit&amp;redlink=1"
+                                                        class="new"
+                                                        title="Rajendravarman I (page does not exist)">Rajendravarman
+                                                        I</a></li><li><a
+                                                        href="/w/index.php?title=Mahipativarman&amp;action=edit&amp;redlink=1"
+                                                        class="new"
+                                                        title="Mahipativarman (page does not exist)">Mahipativarman</a>
+                                                </li>
+                                            </ul></div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="navbox-group"
+                                        style="background:white; color:black; box-shadow: inset 2px 2px 0 #F0DC82, inset -2px -2px 0 #F0DC82;;width:1%">
+                                        <a href="/wiki/Khmer_Empire" title="Khmer Empire">Khmer Empire</a></th>
+                                    <td class="navbox-list-with-group navbox-list navbox-odd hlist"
+                                        style="width:100%;padding:0">
+                                        <div style="padding:0 0.25em"><ul>
+                                                <li><a href="/wiki/Jayavarman_II" title="Jayavarman II">Jayavarman
+                                                        II</a></li><li><a href="/wiki/Jayavarman_III"
+                                                        title="Jayavarman III">Jayavarman III</a></li><li><a
+                                                        href="/wiki/Indravarman_I" title="Indravarman I">Indravarman
+                                                        I</a></li><li><a href="/wiki/Yasovarman_I"
+                                                        title="Yasovarman I">Yasovarman I</a></li><li><a
+                                                        href="/wiki/Harshavarman_I" title="Harshavarman I">Harshavarman
+                                                        I</a></li><li><a href="/wiki/Ishanavarman_II"
+                                                        title="Ishanavarman II">Ishanavarman II</a></li><li><a
+                                                        href="/wiki/Jayavarman_IV" title="Jayavarman IV">Jayavarman
+                                                        IV</a></li><li><a href="/wiki/Harshavarman_II"
+                                                        title="Harshavarman II">Harshavarman II</a></li><li><a
+                                                        href="/wiki/Rajendravarman_II"
+                                                        title="Rajendravarman II">Rajendravarman II</a></li><li><a
+                                                        href="/wiki/Jayavarman_V" title="Jayavarman V">Jayavarman V</a>
+                                                </li><li><a href="/wiki/Udayadityavarman_I"
+                                                        title="Udayadityavarman I">Udayadityavarman I</a></li><li><a
+                                                        href="/wiki/Jayavirahvarman"
+                                                        title="Jayavirahvarman">Jayavirahvarman</a></li><li><a
+                                                        href="/wiki/Suryavarman_I" title="Suryavarman I">Suryavarman
+                                                        I</a></li><li><a href="/wiki/Udayadityavarman_II"
+                                                        title="Udayadityavarman II">Udayadityavarman II</a></li><li><a
+                                                        href="/wiki/Harshavarman_III"
+                                                        title="Harshavarman III">Harshavarman III</a></li><li><a
+                                                        href="/wiki/Nripatindravarman"
+                                                        title="Nripatindravarman">Nripatindravarman</a></li><li><a
+                                                        href="/wiki/Jayavarman_VI" title="Jayavarman VI">Jayavarman
+                                                        VI</a></li><li><a href="/wiki/Dharanindravarman_I"
+                                                        title="Dharanindravarman I">Dharanindravarman I</a></li><li><a
+                                                        href="/wiki/Suryavarman_II" title="Suryavarman II">Suryavarman
+                                                        II</a></li><li><a href="/wiki/Dharanindravarman_II"
+                                                        title="Dharanindravarman II">Dharanindravarman II</a></li><li>
+                                                    <a href="/wiki/Yasovarman_II" title="Yasovarman II">Yasovarman
+                                                        II</a></li><li><a href="/wiki/Tribhuvanadityavarman"
+                                                        class="mw-redirect"
+                                                        title="Tribhuvanadityavarman">Tribhuvanadityavarman</a></li>
+                                                <li><a href="/wiki/Jayavarman_VII" title="Jayavarman VII">Jayavarman
+                                                        VII</a></li><li><a href="/wiki/Indravarman_II"
+                                                        title="Indravarman II">Indravarman II</a></li><li><a
+                                                        href="/wiki/Jayavarman_VIII" title="Jayavarman VIII">Jayavarman
+                                                        VIII</a></li><li><a href="/wiki/Indravarman_III"
+                                                        title="Indravarman III">Indravarman III</a></li><li><a
+                                                        href="/wiki/Indrajayavarman"
+                                                        title="Indrajayavarman">Indrajayavarman</a></li><li><a
+                                                        href="/wiki/Jayavarman_IX" title="Jayavarman IX">Jayavarman
+                                                        IX</a></li><li><a
+                                                        href="/w/index.php?title=Trosok_Peam&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Trosok Peam (page does not exist)">Trosok
+                                                        Peam</a></li><li><a href="/wiki/Nippean_Bat"
+                                                        title="Nippean Bat">Nippean Bat</a></li><li><a
+                                                        href="/w/index.php?title=Lompong_Racha&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Lompong Racha (page does not exist)">Lompong
+                                                        Racha</a></li><li><a
+                                                        href="/w/index.php?title=Soryavong&amp;action=edit&amp;redlink=1"
+                                                        class="new"
+                                                        title="Soryavong (page does not exist)">Soryavong</a></li><li>
+                                                    <a href="/wiki/Borom_Reachea_I" class="mw-redirect"
+                                                        title="Borom Reachea I">Borom Reachea I</a></li><li><a
+                                                        href="/wiki/Thomma_Saok" class="mw-redirect"
+                                                        title="Thomma Saok">Thomma Saok</a></li><li><a
+                                                        href="/wiki/Intharacha_(king_of_Ayutthaya)"
+                                                        title="Intharacha (king of Ayutthaya)">In Reachea (Ponhea
+                                                        Prek)</a></li><li><a href="/wiki/Ponhea_Yat"
+                                                        title="Ponhea Yat">Barom Reachea II (Ponhea Yat)</a></li>
+                                            </ul></div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="navbox-group"
+                                        style="background:white; color:black; box-shadow: inset 2px 2px 0 #F0DC82, inset -2px -2px 0 #F0DC82;;width:1%">
+                                        <a href="/wiki/Dark_ages_of_Cambodia" class="mw-redirect"
+                                            title="Dark ages of Cambodia">Dark ages</a></th>
+                                    <td class="navbox-list-with-group navbox-list navbox-even hlist"
+                                        style="width:100%;padding:0">
+                                        <div style="padding:0 0.25em"><ul>
+                                                <li><a href="/wiki/Ponhea_Yat" title="Ponhea Yat">Ponhea Yat</a></li>
+                                                <li><a href="/w/index.php?title=Noreay_Ramathipatei&amp;action=edit&amp;redlink=1"
+                                                        class="new"
+                                                        title="Noreay Ramathipatei (page does not exist)">Noreay Reachea
+                                                        I</a></li><li><a
+                                                        href="/w/index.php?title=Reachea_Ramathipatei&amp;action=edit&amp;redlink=1"
+                                                        class="new"
+                                                        title="Reachea Ramathipatei (page does not exist)">Srey Reachea
+                                                        Ramathuppdey</a></li><li><a
+                                                        href="/w/index.php?title=Srei_Soriyotei_II&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Srei Soriyotei II (page does not exist)">Srei
+                                                        Soriyotei II</a></li><li><a
+                                                        href="/w/index.php?title=Thommo_Reachea_I&amp;action=edit&amp;redlink=1"
+                                                        class="new"
+                                                        title="Thommo Reachea I (page does not exist)">Thommo Reachea
+                                                        I</a></li><li><a
+                                                        href="/w/index.php?title=Srey_Sukonthor&amp;action=edit&amp;redlink=1"
+                                                        class="new" title="Srey Sukonthor (page does not exist)">Srey
+                                                        Sukonthor</a></li><li><a href="/wiki/Sdach_Korn"
+                                                        title="Sdach Korn">Sdach Korn</a></li><li><a
+                                                        href="/wiki/Ang_Chan_I" title="Ang Chan I">Ang Chan I</a></li>
+                                                <li><a href="/wiki/Barom_Reachea_I" class="mw-redirect"
+                                                        title="Barom Reachea I">Barom Reachea I</a></li><li><a
+                                                        href="/wiki/Satha_I" title="Satha I">Satha I</a></li><li><a
+                                                        href="/wiki/Chey_Chettha_I" title="Chey Chettha I">Chey Chettha
+                                                        I</a></li><li><a href="/wiki/Preah_Ram_I"
+                                                        title="Preah Ram I">Preah Ram I</a></li><li><a
+                                                        href="/wiki/Preah_Ram_II" title="Preah Ram II">Preah Ram II</a>
+                                                </li><li><a href="/wiki/Barom_Reachea_II"
+                                                        title="Barom Reachea II">Barom Reachea II</a></li><li><a
+                                                        href="/wiki/Barom_Reachea_III" title="Barom Reachea III">Barom
+                                                        Reachea III</a></li><li><a href="/wiki/Kaev_Hua_I"
+                                                        title="Kaev Hua I">Kaev Hua I (Ponhea Nhom)</a></li><li><a
+                                                        href="/wiki/Srei_Soriyopear" title="Srei Soriyopear">Srei
+                                                        Soriyopear</a></li><li><a href="/wiki/Chey_Chettha_II"
+                                                        title="Chey Chettha II">Chey Chettha II</a></li><li><a
+                                                        href="/wiki/Outey" title="Outey">Outey</a> <span
+                                                        style="font-size:85%;">(co-ruler)</span></li><li><a
+                                                        href="/wiki/Thommo_Reachea_II" title="Thommo Reachea II">Thommo
+                                                        Reachea II (Ponhea To)</a></li><li><a
+                                                        href="/wiki/Ang_Tong_Reachea" title="Ang Tong Reachea">Ang Tong
+                                                        Reachea (Ponhea Nu)</a></li><li><a href="/wiki/Batom_Reachea"
+                                                        title="Batom Reachea">Batom Reachea (Ang Non I)</a></li><li><a
+                                                        href="/wiki/Ramathipadi_I" title="Ramathipadi I">Ponhea Chan
+                                                        (Sultan Ibrahim)</a></li><li><a href="/wiki/Barom_Reachea_V"
+                                                        title="Barom Reachea V">Barom Reachea V</a></li><li><a
+                                                        href="/wiki/Chey_Chettha_III" title="Chey Chettha III">Chey
+                                                        Chettha III</a></li><li><a href="/wiki/Kaev_Hua_II"
+                                                        title="Kaev Hua II">Kaev Hua II</a></li><li><a
+                                                        class="mw-selflink selflink">Ang Nan</a></li><li><a
+                                                        href="/wiki/Chey_Chettha_IV" title="Chey Chettha IV">Chey
+                                                        Chettha IV</a></li><li><a href="/wiki/Queen_Tey"
+                                                        title="Queen Tey">Queen Tey</a> <span
+                                                        style="font-size:85%;">(female)</span></li><li><a
+                                                        href="/wiki/Outey_I" title="Outey I">Outey I</a></li><li><a
+                                                        href="/wiki/Ang_Em" title="Ang Em">Kaev Hua III (Ang Em)</a>
+                                                </li><li><a href="/wiki/Thommo_Reachea_III"
+                                                        title="Thommo Reachea III">Thommo Reachea III</a></li><li><a
+                                                        href="/wiki/Satha_II" title="Satha II">Satha II</a></li><li><a
+                                                        href="/wiki/Thommo_Reachea_IV" title="Thommo Reachea IV">Thommo
+                                                        Reachea IV</a></li><li><a href="/wiki/Ang_Tong"
+                                                        title="Ang Tong">Ang Tong</a></li><li><a
+                                                        href="/wiki/Chey_Chettha_V" title="Chey Chettha V">Ang
+                                                        Sngoun</a></li><li><a href="/wiki/Outey_II"
+                                                        title="Outey II">Noreay Reachea II (Outey II)</a></li><li><a
+                                                        href="/wiki/Ang_Non_II" title="Ang Non II">Ang Non II</a></li>
+                                                <li><a href="/wiki/Ang_Eng" title="Ang Eng">Noreay Reachea III (Ang
+                                                        Eng)</a></li><li><a href="/wiki/Ang_Chan_II"
+                                                        title="Ang Chan II">Ang Chan II</a></li><li><a
+                                                        href="/wiki/Ang_Mey" title="Ang Mey">Ang Mey</a> <span
+                                                        style="font-size:85%;">(female)</span></li><li><a
+                                                        href="/wiki/Ang_Duong" title="Ang Duong">Ang Duong</a></li>
+                                            </ul></div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="navbox-group"
+                                        style="background:white; color:black; box-shadow: inset 2px 2px 0 #F0DC82, inset -2px -2px 0 #F0DC82;;width:1%">
+                                        <a href="/wiki/French_Protectorate_of_Cambodia" class="mw-redirect"
+                                            title="French Protectorate of Cambodia">French Protectorate</a></th>
+                                    <td class="navbox-list-with-group navbox-list navbox-odd hlist"
+                                        style="width:100%;padding:0">
+                                        <div style="padding:0 0.25em"><ul>
+                                                <li><a href="/wiki/Norodom_of_Cambodia"
+                                                        title="Norodom of Cambodia">Norodom</a></li><li><a
+                                                        href="/wiki/Sisowath_of_Cambodia"
+                                                        title="Sisowath of Cambodia">Sisowath</a></li><li><a
+                                                        href="/wiki/Sisowath_Monivong"
+                                                        title="Sisowath Monivong">Sisowath Monivong</a></li><li><a
+                                                        href="/wiki/Norodom_Sihanouk" title="Norodom Sihanouk">Norodom
+                                                        Sihanouk</a></li>
+                                            </ul></div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="navbox-group"
+                                        style="background:white; color:black; box-shadow: inset 2px 2px 0 #F0DC82, inset -2px -2px 0 #F0DC82;;width:1%">
+                                        Modern Cambodia</th>
+                                    <td class="navbox-list-with-group navbox-list navbox-even hlist"
+                                        style="width:100%;padding:0">
+                                        <div style="padding:0 0.25em"><ul>
+                                                <li><a href="/wiki/Norodom_Suramarit" title="Norodom Suramarit">Norodom
+                                                        Suramarit</a></li><li><a href="/wiki/Norodom_Sihanouk"
+                                                        title="Norodom Sihanouk">Norodom Sihanouk</a></li><li><a
+                                                        href="/wiki/Norodom_Sihamoni" title="Norodom Sihamoni">Norodom
+                                                        Sihamoni</a></li>
+                                            </ul></div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!-- NewPP limit reportParsed by mw1378Cached time: 20211210200752Cache expiry: 1814400Reduced expiry: falseComplications: [vary\u2010revision\u2010sha1]CPU time usage: 0.570 secondsReal time usage: 0.769 secondsPreprocessor visited node count: 1969/1000000Post\u2010expand include size: 41224/2097152 bytesTemplate argument size: 1829/2097152 bytesHighest expansion depth: 17/40Expensive parser function count: 1/500Unstrip recursion depth: 0/20Unstrip post\u2010expand size: 5035/5000000 bytesLua time usage: 0.318/10.000 secondsLua memory usage: 16760281/52428800 bytesNumber of Wikibase entities loaded: 0/400-->
+                    <!--Transclusion expansion time report (%,ms,calls,template)100.00%  686.760      1 -total 23.06%  158.393      1 Template:Lang-km 22.58%  155.084      1 Template:Infobox_royalty 16.55%  113.640      1 Template:More_footnotes 16.52%  113.466      2 Template:Short_description 13.11%   90.054      2 Template:Infobox 12.83%   88.113      1 Template:Monarchs_of_Cambodia 12.17%   83.577      1 Template:Navbox 11.26%   77.353      1 Template:Ambox  8.90%   61.122      1 Template:Infobox_royalty/short_description-->
+                    <!-- Saved in parser cache with key enwiki:pcache:idhash:59327864-0!canonical and timestamp 20211210200751 and revision id 1018803899. Serialized with JSON. -->
+                </div><noscript><img src="//en.wikipedia.org/wiki/Special:CentralAutoLogin/start?type=1x1" alt=""
+                        title="" width="1" height="1" style="border: none; position: absolute;" /></noscript><div
+                    class="printfooter">Retrieved from "<a dir="ltr"
+                        href="https://en.wikipedia.org/w/index.php?title=Ang_Nan&amp;oldid=1018803899">https://en.wikipedia.org/w/index.php?title=Ang_Nan&amp;oldid=1018803899</a>"
+                </div>
+            </div>\t\t<div id="catlinks" class="catlinks" data-mw="interface">
+                <div id="mw-normal-catlinks" class="mw-normal-catlinks"><a href="/wiki/Help:Category"
+                        title="Help:Category">Categories</a>: <ul>
+                        <li><a href="/wiki/Category:1654_births" title="Category:1654 births">1654 births</a></li>
+                        <li><a href="/wiki/Category:1691_deaths" title="Category:1691 deaths">1691 deaths</a></li>
+                        <li><a href="/wiki/Category:17th-century_Cambodian_monarchs"
+                                title="Category:17th-century Cambodian monarchs">17th-century Cambodian monarchs</a>
+                        </li>
+                        <li><a href="/wiki/Category:Monarchs_who_abdicated"
+                                title="Category:Monarchs who abdicated">Monarchs who abdicated</a></li>
+                    </ul>
+                </div>
+                <div id="mw-hidden-catlinks" class="mw-hidden-catlinks mw-hidden-cats-hidden">Hidden categories: <ul>
+                        <li><a href="/wiki/Category:Articles_lacking_in-text_citations_from_August_2020"
+                                title="Category:Articles lacking in-text citations from August 2020">Articles lacking
+                                in-text citations from August 2020</a></li>
+                        <li><a href="/wiki/Category:All_articles_lacking_in-text_citations"
+                                title="Category:All articles lacking in-text citations">All articles lacking in-text
+                                citations</a></li>
+                        <li><a href="/wiki/Category:Articles_with_short_description"
+                                title="Category:Articles with short description">Articles with short description</a>
+                        </li>
+                        <li><a href="/wiki/Category:Short_description_matches_Wikidata"
+                                title="Category:Short description matches Wikidata">Short description matches
+                                Wikidata</a></li>
+                        <li><a href="/wiki/Category:Articles_containing_Khmer-language_text"
+                                title="Category:Articles containing Khmer-language text">Articles containing
+                                Khmer-language text</a></li>
+                    </ul>
+                </div>
+            </div>\t</div></div><div id=\'mw-data-after-content\'>\t<div class="read-more-container"></div>
+    </div><div id="mw-navigation">\t<h2>Navigation menu</h2>\t<div id="mw-head">\t\t<nav id="p-personal"
+                class="mw-portlet mw-portlet-personal vector-user-menu-legacy vector-menu"
+                aria-labelledby="p-personal-label" role="navigation" \t>\t<h3 id="p-personal-label" aria-label=""
+                    class="vector-menu-heading">\t\t<span class="vector-menu-heading-label">Personal tools</span>\t
+                </h3>\t<div class="vector-menu-content">\t\t\t\t<ul class="vector-menu-content-list">
+                        <li id="pt-anonuserpage" class="mw-list-item"><span>Not logged in</span></li>
+                        <li id="pt-anontalk" class="mw-list-item"><a href="/wiki/Special:MyTalk"
+                                title="Discussion about edits from this IP address [n]"
+                                accesskey="n"><span>Talk</span></a></li>
+                        <li id="pt-anoncontribs" class="mw-list-item"><a href="/wiki/Special:MyContributions"
+                                title="A list of edits made from this IP address [y]"
+                                accesskey="y"><span>Contributions</span></a></li>
+                        <li id="pt-createaccount" class="mw-list-item"><a
+                                href="/w/index.php?title=Special:CreateAccount&amp;returnto=Ang+Nan"
+                                title="You are encouraged to create an account and log in; however, it is not mandatory"><span>Create
+                                    account</span></a></li>
+                        <li id="pt-login" class="mw-list-item"><a
+                                href="/w/index.php?title=Special:UserLogin&amp;returnto=Ang+Nan"
+                                title="You&#039;re encouraged to log in; however, it&#039;s not mandatory. [o]"
+                                accesskey="o"><span>Log in</span></a></li>
+                    </ul>\t\t\t</div></nav>\t\t<div id="left-navigation">\t\t\t<nav id="p-namespaces"
+                    class="mw-portlet mw-portlet-namespaces vector-menu vector-menu-tabs"
+                    aria-labelledby="p-namespaces-label" role="navigation" \t>\t<h3 id="p-namespaces-label"
+                        aria-label="" class="vector-menu-heading">\t\t<span
+                            class="vector-menu-heading-label">Namespaces</span>\t</h3>\t<div
+                        class="vector-menu-content">\t\t\t\t<ul class="vector-menu-content-list">
+                            <li id="ca-nstab-main" class="selected mw-list-item"><a href="/wiki/Ang_Nan"
+                                    title="View the content page [c]" accesskey="c"><span>Article</span></a></li>
+                            <li id="ca-talk" class="mw-list-item"><a href="/wiki/Talk:Ang_Nan" rel="discussion"
+                                    title="Discuss improvements to the content page [t]"
+                                    accesskey="t"><span>Talk</span></a></li>
+                        </ul>\t\t\t</div></nav>\t\t\t<nav id="p-variants"
+                    class="mw-portlet mw-portlet-variants emptyPortlet vector-menu-dropdown-noicon vector-menu vector-menu-dropdown"
+                    aria-labelledby="p-variants-label" role="navigation" \t>\t<input type="checkbox"
+                        \t\tid="p-variants-checkbox" \t\trole="button" \t\taria-haspopup="true"
+                        \t\tdata-event-name="ui.dropdown-p-variants" \t\tclass="vector-menu-checkbox"
+                        aria-labelledby="p-variants-label" />\t<h3 id="p-variants-label"
+                        aria-label="Change language variant" class="vector-menu-heading">\t\t<span
+                            class="vector-menu-heading-label">Variants</span>\t\t\t<span
+                            class="vector-menu-checkbox-expanded">expanded</span>\t\t\t<span
+                            class="vector-menu-checkbox-collapsed">collapsed</span>\t</h3>\t<div
+                        class="vector-menu-content">\t\t\t\t<ul class="vector-menu-content-list"></ul>\t\t\t
+                    </div></nav>\t\t</div>\t\t<div id="right-navigation">\t\t\t<nav id="p-views"
+                    class="mw-portlet mw-portlet-views vector-menu vector-menu-tabs" aria-labelledby="p-views-label"
+                    role="navigation" \t>\t<h3 id="p-views-label" aria-label="" class="vector-menu-heading">
+                        \t\t<span class="vector-menu-heading-label">Views</span>\t</h3>\t<div
+                        class="vector-menu-content">\t\t\t\t<ul class="vector-menu-content-list">
+                            <li id="ca-view" class="selected mw-list-item"><a href="/wiki/Ang_Nan"><span>Read</span></a>
+                            </li>
+                            <li id="ca-edit" class="mw-list-item"><a href="/w/index.php?title=Ang_Nan&amp;action=edit"
+                                    title="Edit this page [e]" accesskey="e"><span>Edit</span></a></li>
+                            <li id="ca-history" class="mw-list-item"><a
+                                    href="/w/index.php?title=Ang_Nan&amp;action=history"
+                                    title="Past revisions of this page [h]" accesskey="h"><span>View history</span></a>
+                            </li>
+                        </ul>\t\t\t</div></nav>\t\t\t<nav id="p-cactions"
+                    class="mw-portlet mw-portlet-cactions emptyPortlet vector-menu-dropdown-noicon vector-menu vector-menu-dropdown"
+                    aria-labelledby="p-cactions-label" role="navigation" title="More options" \t>\t<input
+                        type="checkbox" \t\tid="p-cactions-checkbox" \t\trole="button" \t\taria-haspopup="true"
+                        \t\tdata-event-name="ui.dropdown-p-cactions" \t\tclass="vector-menu-checkbox"
+                        aria-labelledby="p-cactions-label" />\t<h3 id="p-cactions-label" aria-label=""
+                        class="vector-menu-heading">\t\t<span
+                            class="vector-menu-heading-label">More</span>\t\t\t<span
+                            class="vector-menu-checkbox-expanded">expanded</span>\t\t\t<span
+                            class="vector-menu-checkbox-collapsed">collapsed</span>\t</h3>\t<div
+                        class="vector-menu-content">\t\t\t\t<ul class="vector-menu-content-list"></ul>\t\t\t
+                    </div></nav>\t\t\t<div id="p-search" role="search" class=" vector-search-box">\t<div>
+                        \t\t\t<h3>\t\t\t\t<label for="searchInput">Search</label>\t\t\t</h3>\t\t<form
+                            action="/w/index.php" id="searchform" \t\t\tclass="vector-search-box-form">\t\t\t<div
+                                id="simpleSearch" \t\t\t\tclass="vector-search-box-inner" \t\t\t\t
+                                data-search-loc="header-navigation">\t\t\t\t<input class="vector-search-box-input"
+                                    \t\t\t\t\t type="search" name="search" placeholder="Search Wikipedia"
+                                    aria-label="Search Wikipedia" autocapitalize="sentences"
+                                    title="Search Wikipedia [f]" accesskey="f" id="searchInput"
+                                    \t\t\t\t />\t\t\t\t<input type="hidden" name="title"
+                                    value="Special:Search" />\t\t\t\t<input id="mw-searchButton" \t\t\t\t\t
+                                    class="searchButton mw-fallbackSearchButton" type="submit" name="fulltext"
+                                    title="Search Wikipedia for this text" value="Search" />\t\t\t\t<input
+                                    id="searchButton" \t\t\t\t\t class="searchButton" type="submit" name="go"
+                                    title="Go to a page with this exact name if it exists" value="Go" />\t\t\t</div>
+                            \t\t</form>\t</div></div>\t\t</div>\t</div>\t<div id="mw-panel">\t<div
+                id="p-logo" role="banner">\t\t<a class="mw-wiki-logo" href="/wiki/Main_Page"
+                    \t\t\ttitle="Visit the main page"></a>\t</div>\t<nav id="p-navigation"
+                class="mw-portlet mw-portlet-navigation vector-menu vector-menu-portal portal"
+                aria-labelledby="p-navigation-label" role="navigation" \t>\t<h3 id="p-navigation-label"
+                    aria-label="" class="vector-menu-heading">\t\t<span
+                        class="vector-menu-heading-label">Navigation</span>\t</h3>\t<div
+                    class="vector-menu-content">\t\t\t\t<ul class="vector-menu-content-list">
+                        <li id="n-mainpage-description" class="mw-list-item"><a href="/wiki/Main_Page"
+                                title="Visit the main page [z]" accesskey="z"><span>Main page</span></a></li>
+                        <li id="n-contents" class="mw-list-item"><a href="/wiki/Wikipedia:Contents"
+                                title="Guides to browsing Wikipedia"><span>Contents</span></a></li>
+                        <li id="n-currentevents" class="mw-list-item"><a href="/wiki/Portal:Current_events"
+                                title="Articles related to current events"><span>Current events</span></a></li>
+                        <li id="n-randompage" class="mw-list-item"><a href="/wiki/Special:Random"
+                                title="Visit a randomly selected article [x]" accesskey="x"><span>Random
+                                    article</span></a></li>
+                        <li id="n-aboutsite" class="mw-list-item"><a href="/wiki/Wikipedia:About"
+                                title="Learn about Wikipedia and how it works"><span>About Wikipedia</span></a></li>
+                        <li id="n-contactpage" class="mw-list-item"><a
+                                href="//en.wikipedia.org/wiki/Wikipedia:Contact_us"
+                                title="How to contact Wikipedia"><span>Contact us</span></a></li>
+                        <li id="n-sitesupport" class="mw-list-item"><a
+                                href="https://donate.wikimedia.org/wiki/Special:FundraiserRedirector?utm_source=donate&amp;utm_medium=sidebar&amp;utm_campaign=C13_en.wikipedia.org&amp;uselang=en"
+                                title="Support us by donating to the Wikimedia Foundation"><span>Donate</span></a></li>
+                    </ul>\t\t\t</div></nav>\t<nav id="p-interaction"
+                class="mw-portlet mw-portlet-interaction vector-menu vector-menu-portal portal"
+                aria-labelledby="p-interaction-label" role="navigation" \t>\t<h3 id="p-interaction-label"
+                    aria-label="" class="vector-menu-heading">\t\t<span
+                        class="vector-menu-heading-label">Contribute</span>\t</h3>\t<div
+                    class="vector-menu-content">\t\t\t\t<ul class="vector-menu-content-list">
+                        <li id="n-help" class="mw-list-item"><a href="/wiki/Help:Contents"
+                                title="Guidance on how to use and edit Wikipedia"><span>Help</span></a></li>
+                        <li id="n-introduction" class="mw-list-item"><a href="/wiki/Help:Introduction"
+                                title="Learn how to edit Wikipedia"><span>Learn to edit</span></a></li>
+                        <li id="n-portal" class="mw-list-item"><a href="/wiki/Wikipedia:Community_portal"
+                                title="The hub for editors"><span>Community portal</span></a></li>
+                        <li id="n-recentchanges" class="mw-list-item"><a href="/wiki/Special:RecentChanges"
+                                title="A list of recent changes to Wikipedia [r]" accesskey="r"><span>Recent
+                                    changes</span></a></li>
+                        <li id="n-upload" class="mw-list-item"><a href="/wiki/Wikipedia:File_Upload_Wizard"
+                                title="Add images or other media for use on Wikipedia"><span>Upload file</span></a></li>
+                    </ul>\t\t\t</div></nav><nav id="p-tb"
+                class="mw-portlet mw-portlet-tb vector-menu vector-menu-portal portal" aria-labelledby="p-tb-label"
+                role="navigation" \t>\t<h3 id="p-tb-label" aria-label="" class="vector-menu-heading">\t\t<span
+                        class="vector-menu-heading-label">Tools</span>\t</h3>\t<div class="vector-menu-content">
+                    \t\t\t\t<ul class="vector-menu-content-list">
+                        <li id="t-whatlinkshere" class="mw-list-item"><a href="/wiki/Special:WhatLinksHere/Ang_Nan"
+                                title="List of all English Wikipedia pages containing links to this page [j]"
+                                accesskey="j"><span>What links here</span></a></li>
+                        <li id="t-recentchangeslinked" class="mw-list-item"><a
+                                href="/wiki/Special:RecentChangesLinked/Ang_Nan" rel="nofollow"
+                                title="Recent changes in pages linked from this page [k]" accesskey="k"><span>Related
+                                    changes</span></a></li>
+                        <li id="t-upload" class="mw-list-item"><a href="/wiki/Wikipedia:File_Upload_Wizard"
+                                title="Upload files [u]" accesskey="u"><span>Upload file</span></a></li>
+                        <li id="t-specialpages" class="mw-list-item"><a href="/wiki/Special:SpecialPages"
+                                title="A list of all special pages [q]" accesskey="q"><span>Special pages</span></a>
+                        </li>
+                        <li id="t-permalink" class="mw-list-item"><a
+                                href="/w/index.php?title=Ang_Nan&amp;oldid=1018803899"
+                                title="Permanent link to this revision of this page"><span>Permanent link</span></a>
+                        </li>
+                        <li id="t-info" class="mw-list-item"><a href="/w/index.php?title=Ang_Nan&amp;action=info"
+                                title="More information about this page"><span>Page information</span></a></li>
+                        <li id="t-cite" class="mw-list-item"><a
+                                href="/w/index.php?title=Special:CiteThisPage&amp;page=Ang_Nan&amp;id=1018803899&amp;wpFormIdentifier=titleform"
+                                title="Information on how to cite this page"><span>Cite this page</span></a></li>
+                        <li id="t-wikibase" class="mw-list-item"><a
+                                href="https://www.wikidata.org/wiki/Special:EntityPage/Q2849239"
+                                title="Structured data on this page hosted by Wikidata [g]" accesskey="g"><span>Wikidata
+                                    item</span></a></li>
+                    </ul>\t\t\t</div></nav><nav id="p-coll-print_export"
+                class="mw-portlet mw-portlet-coll-print_export vector-menu vector-menu-portal portal"
+                aria-labelledby="p-coll-print_export-label" role="navigation" \t>\t<h3
+                    id="p-coll-print_export-label" aria-label="" class="vector-menu-heading">\t\t<span
+                        class="vector-menu-heading-label">Print/export</span>\t</h3>\t<div
+                    class="vector-menu-content">\t\t\t\t<ul class="vector-menu-content-list">
+                        <li id="coll-download-as-rl" class="mw-list-item"><a
+                                href="/w/index.php?title=Special:DownloadAsPdf&amp;page=Ang_Nan&amp;action=show-download-screen"
+                                title="Download this page as a PDF file"><span>Download as PDF</span></a></li>
+                        <li id="t-print" class="mw-list-item"><a href="/w/index.php?title=Ang_Nan&amp;printable=yes"
+                                title="Printable version of this page [p]" accesskey="p"><span>Printable
+                                    version</span></a></li>
+                    </ul>\t\t\t</div></nav>\t<nav id="p-lang"
+                class="mw-portlet mw-portlet-lang vector-menu vector-menu-portal portal" aria-labelledby="p-lang-label"
+                role="navigation" \t>\t<h3 id="p-lang-label" aria-label="" class="vector-menu-heading">\t\t<span
+                        class="vector-menu-heading-label">Languages</span>\t</h3>\t<div class="vector-menu-content">
+                    \t\t\t\t<ul class="vector-menu-content-list">
+                        <li class="interlanguage-link interwiki-ar mw-list-item"><a
+                                href="https://ar.wikipedia.org/wiki/%D8%A3%D9%86%D8%BA_%D9%86%D8%A7%D9%86"
+                                title="\u0623\u0646\u063a \u0646\u0627\u0646 \u2013 Arabic" lang="ar" hreflang="ar"
+                                class="interlanguage-link-target"><span>\u0627\u0644\u0639\u0631\u0628\u064a\u0629</span></a>
+                        </li>
+                        <li class="interlanguage-link interwiki-zh-min-nan mw-list-item"><a
+                                href="https://zh-min-nan.wikipedia.org/wiki/Ang_Nan"
+                                title="Ang Nan \u2013 Chinese (Min Nan)" lang="nan" hreflang="nan"
+                                class="interlanguage-link-target"><span>B\xe2n-l\xe2m-g\xfa</span></a></li>
+                        <li class="interlanguage-link interwiki-fr mw-list-item"><a
+                                href="https://fr.wikipedia.org/wiki/Ang_Nan" title="Ang Nan \u2013 French" lang="fr"
+                                hreflang="fr" class="interlanguage-link-target"><span>Fran\xe7ais</span></a></li>
+                        <li class="interlanguage-link interwiki-arz mw-list-item"><a
+                                href="https://arz.wikipedia.org/wiki/%D8%A7%D9%86%D8%AC_%D9%86%D8%A7%D9%86"
+                                title="\u0627\u0646\u062c \u0646\u0627\u0646 \u2013 Egyptian Arabic" lang="arz"
+                                hreflang="arz"
+                                class="interlanguage-link-target"><span>\u0645\u0635\u0631\u0649</span></a></li>
+                        <li class="interlanguage-link interwiki-km mw-list-item"><a
+                                href="https://km.wikipedia.org/wiki/%E1%9E%94%E1%9E%91%E1%9E%BB%E1%9E%98%E1%9E%9A%E1%9E%B6%E1%9E%87%E1%9E%B6%E1%9E%91%E1%9E%B8%E1%9F%A3"
+                                title="\u1794\u1791\u17bb\u1798\u179a\u17b6\u1787\u17b6\u1791\u17b8\u17e3 \u2013 Khmer"
+                                lang="km" hreflang="km"
+                                class="interlanguage-link-target"><span>\u1797\u17b6\u179f\u17b6\u1781\u17d2\u1798\u17c2\u179a</span></a>
+                        </li>
+                        <li class="interlanguage-link interwiki-ru mw-list-item"><a
+                                href="https://ru.wikipedia.org/wiki/%D0%90%D0%BD%D0%B3_%D0%9D%D0%BE%D0%BD_II"
+                                title="\u0410\u043d\u0433 \u041d\u043e\u043d II \u2013 Russian" lang="ru" hreflang="ru"
+                                class="interlanguage-link-target"><span>\u0420\u0443\u0441\u0441\u043a\u0438\u0439</span></a>
+                        </li>
+                        <li class="interlanguage-link interwiki-uk mw-list-item"><a
+                                href="https://uk.wikipedia.org/wiki/%D0%90%D0%BD%D0%B3_%D0%9D%D0%BE%D0%BD_II"
+                                title="\u0410\u043d\u0433 \u041d\u043e\u043d II \u2013 Ukrainian" lang="uk"
+                                hreflang="uk"
+                                class="interlanguage-link-target"><span>\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430</span></a>
+                        </li>
+                        <li class="interlanguage-link interwiki-vi mw-list-item"><a
+                                href="https://vi.wikipedia.org/wiki/Ang_Nan_II" title="Ang Nan II \u2013 Vietnamese"
+                                lang="vi" hreflang="vi" class="interlanguage-link-target"><span>Ti\u1ebfng
+                                    Vi\u1ec7t</span></a></li>
+                        <li class="interlanguage-link interwiki-zh mw-list-item"><a
+                                href="https://zh.wikipedia.org/wiki/%E5%AE%89%E5%8D%97%E4%BA%8C%E4%B8%96"
+                                title="\u5b89\u5357\u4e8c\u4e16 \u2013 Chinese" lang="zh" hreflang="zh"
+                                class="interlanguage-link-target"><span>\u4e2d\u6587</span></a></li>
+                    </ul>\t\t<div class="after-portlet after-portlet-lang"><span
+                            class="wb-langlinks-edit wb-langlinks-link"><a
+                                href="https://www.wikidata.org/wiki/Special:EntityPage/Q2849239#sitelinks-wikipedia"
+                                title="Edit interlanguage links" class="wbc-editpage">Edit links</a></span></div>\t
+                </div></nav></div></div><footer id="footer" class="mw-footer" role="contentinfo">\t<ul
+            id="footer-info">\t<li id="footer-info-lastmod"> This page was last edited on 19 April 2021, at 23:39<span
+                    class="anonymous-show">&#160;(UTC)</span>.</li>\t<li id="footer-info-copyright">Text is available
+                under the <a rel="license"
+                    href="//en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License">Creative
+                    Commons Attribution-ShareAlike License</a><a rel="license"
+                    href="//creativecommons.org/licenses/by-sa/3.0/" style="display:none;"></a>;additional terms may
+                apply. By using this site, you agree to the <a href="//foundation.wikimedia.org/wiki/Terms_of_Use">Terms
+                    of Use</a> and <a href="//foundation.wikimedia.org/wiki/Privacy_policy">Privacy Policy</a>.
+                Wikipedia\xae is a registered trademark of the <a href="//www.wikimediafoundation.org/">Wikimedia
+                    Foundation, Inc.</a>, a non-profit organization.</li></ul>\t<ul id="footer-places">\t<li
+                id="footer-places-privacy"><a href="https://foundation.wikimedia.org/wiki/Privacy_policy" class="extiw"
+                    title="wmf:Privacy policy">Privacy policy</a></li>\t<li id="footer-places-about"><a
+                    href="/wiki/Wikipedia:About" title="Wikipedia:About">About Wikipedia</a></li>\t<li
+                id="footer-places-disclaimer"><a href="/wiki/Wikipedia:General_disclaimer"
+                    title="Wikipedia:General disclaimer">Disclaimers</a></li>\t<li id="footer-places-contact"><a
+                    href="//en.wikipedia.org/wiki/Wikipedia:Contact_us">Contact Wikipedia</a></li>\t<li
+                id="footer-places-mobileview"><a
+                    href="//en.m.wikipedia.org/w/index.php?title=Ang_Nan&amp;mobileaction=toggle_view_mobile"
+                    class="noprint stopMobileRedirectToggle">Mobile view</a></li>\t<li id="footer-places-developers">
+                <a href="https://www.mediawiki.org/wiki/Special:MyLanguage/How_to_contribute">Developers</a></li>\t<li
+                id="footer-places-statslink"><a href="https://stats.wikimedia.org/#/en.wikipedia.org">Statistics</a>
+            </li>\t<li id="footer-places-cookiestatement"><a
+                    href="https://foundation.wikimedia.org/wiki/Cookie_statement">Cookie statement</a></li></ul>\t
+        <ul id="footer-icons" class="noprint">\t<li id="footer-copyrightico"><a
+                    href="https://wikimediafoundation.org/"><img src="/static/images/footer/wikimedia-button.png"
+                        srcset="/static/images/footer/wikimedia-button-1.5x.png 1.5x, /static/images/footer/wikimedia-button-2x.png 2x"
+                        width="88" height="31" alt="Wikimedia Foundation" loading="lazy" /></a></li>\t<li
+                id="footer-poweredbyico"><a href="https://www.mediawiki.org/"><img
+                        src="/static/images/footer/poweredby_mediawiki_88x31.png" alt="Powered by MediaWiki"
+                        srcset="/static/images/footer/poweredby_mediawiki_132x47.png 1.5x, /static/images/footer/poweredby_mediawiki_176x62.png 2x"
+                        width="88" height="31" loading="lazy" /></a></li></ul></footer>
+    <script>(RLQ = window.RLQ || []).push(function () { mw.config.set({ "wgPageParseReport": { "limitreport": { "cputime": "0.570", "walltime": "0.769", "ppvisitednodes": { "value": 1969, "limit": 1000000 }, "postexpandincludesize": { "value": 41224, "limit": 2097152 }, "templateargumentsize": { "value": 1829, "limit": 2097152 }, "expansiondepth": { "value": 17, "limit": 40 }, "expensivefunctioncount": { "value": 1, "limit": 500 }, "unstrip-depth": { "value": 0, "limit": 20 }, "unstrip-size": { "value": 5035, "limit": 5000000 }, "entityaccesscount": { "value": 0, "limit": 400 }, "timingprofile": ["100.00%  686.760      1 -total", " 23.06%  158.393      1 Template:Lang-km", " 22.58%  155.084      1 Template:Infobox_royalty", " 16.55%  113.640      1 Template:More_footnotes", " 16.52%  113.466      2 Template:Short_description", " 13.11%   90.054      2 Template:Infobox", " 12.83%   88.113      1 Template:Monarchs_of_Cambodia", " 12.17%   83.577      1 Template:Navbox", " 11.26%   77.353      1 Template:Ambox", "  8.90%   61.122      1 Template:Infobox_royalty/short_description"] }, "scribunto": { "limitreport-timeusage": { "value": "0.318", "limit": "10.000" }, "limitreport-memusage": { "value": 16760281, "limit": 52428800 } }, "cachereport": { "origin": "mw1378", "timestamp": "20211210200752", "ttl": 1814400, "transientcontent": false } } }); });</script>
+    
+    <script
+        type="application/ld+json">{"@context":"https:\\/\\/schema.org","@type":"Article","name":"Ang Nan","url":"https:\\/\\/en.wikipedia.org\\/wiki\\/Ang_Nan","sameAs":"http:\\/\\/www.wikidata.org\\/entity\\/Q2849239","mainEntity":"http:\\/\\/www.wikidata.org\\/entity\\/Q2849239","author":{"@type":"Organization","name":"Contributors to Wikimedia projects"},"publisher":{"@type":"Organization","name":"Wikimedia Foundation, Inc.","logo":{"@type":"ImageObject","url":"https:\\/\\/www.wikimedia.org\\/static\\/images\\/wmf-hor-googpub.png"}},"datePublished":"2018-12-09T06:25:26Z","dateModified":"2021-04-19T23:39:35Z","headline":"king of Cambodia"}</script>
+    
+    <script>(RLQ = window.RLQ || []).push(function () { mw.config.set({ "wgBackendResponseTime": 153, "wgHostname": "mw1432" }); });</script>
+    
+</body>
+
+</html>


### PR DESCRIPTION
Hacker News had a rate limit for the number of requests we could make. For more info, look at #1 
In this PR we replaced Hacker News with [Wikipedia Special Random page](https://en.wikipedia.org/wiki/Special:Random). So instead of making call to HN page 1 to 20 we make 20 calls to the Wikipedia Random articles page